### PR TITLE
fix(install): expose banyan binaries on sudo secure_path via symlink

### DIFF
--- a/cmd/banyan-cli/cmd/deploy.go
+++ b/cmd/banyan-cli/cmd/deploy.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	deployFile   string
-	deployDryRun bool
-	deployNoWait bool
-	deployTags   []string
+	deployFile     string
+	deployDryRun   bool
+	deployNoWait   bool
+	deployTags     []string
+	deployPlatform string
 )
 
 // Function variables for external commands, enabling test mocking.
@@ -70,6 +71,7 @@ func init() {
 	deployCmd.Flags().BoolVar(&deployDryRun, "dry-run", false, "Validate manifest without deploying")
 	deployCmd.Flags().BoolVar(&deployNoWait, "no-wait", false, "Don't wait for deployment to complete")
 	deployCmd.Flags().StringSliceVar(&deployTags, "tags", nil, "Deployment tags for agent matching")
+	deployCmd.Flags().StringVar(&deployPlatform, "platform", "", "Override build platform for all build services (e.g., linux/arm64)")
 }
 
 // validateServiceArgs checks that all requested service names exist in the manifest.
@@ -105,10 +107,13 @@ func validateManifest(manifest types.BanyanManifest) error {
 }
 
 // buildImageArgs constructs nerdctl build arguments.
-func buildImageArgs(imageName, contextPath, dockerfile string) []string {
+func buildImageArgs(imageName, contextPath, dockerfile, platform string) []string {
 	args := []string{"build", "-t", imageName}
 	if dockerfile != "" {
 		args = append(args, "-f", filepath.Join(contextPath, dockerfile))
+	}
+	if platform != "" {
+		args = append(args, "--platform", platform)
 	}
 	args = append(args, contextPath)
 	return args
@@ -142,11 +147,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Build images for services with build config
+	// Resolve manifest-relative paths (build happens later, after we know the
+	// target agents' architecture — see below).
 	manifestDir := filepath.Dir(deployFile)
-	if buildErr := buildServiceImages(manifestDir, manifest.Name, manifest.Services); buildErr != nil {
-		return buildErr
-	}
 
 	// Resolve env_file references
 	if resolveErr := types.ResolveEnvFiles(manifestDir, manifest.Services); resolveErr != nil {
@@ -157,6 +160,14 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	types.ResolveManifestVolumes(manifestDir, &manifest)
 
 	if deployDryRun {
+		// Offline: no engine to ask, so build for host arch. --platform still honored.
+		applyPlatformOverride(manifest.Services, deployPlatform)
+		if emuErr := checkEmulation(collectBuildPlatforms(manifest.Services)); emuErr != nil {
+			return emuErr
+		}
+		if buildErr := buildServiceImages(manifestDir, manifest.Name, manifest.Services); buildErr != nil {
+			return buildErr
+		}
 		services := types.BuildServiceRecords(manifest.Services)
 		fmt.Printf("Application: %s\n", manifest.Name)
 		fmt.Printf("Services: %d\n", len(manifest.Services))
@@ -186,6 +197,23 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	info, err := client.Info(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to connect to engine: %w", err)
+	}
+
+	// Resolve each build service's target platform from the cluster's agents,
+	// then build. --platform flag overrides everything; missing arch info falls
+	// back to host arch (with a warning) so older/offline-ish clusters still work.
+	st, statusErr := client.Status(ctx)
+	if statusErr != nil {
+		logging.Warn("Could not list agents; building for host arch", "err", statusErr)
+	} else {
+		applyResolvedPlatforms(manifest.Services, st.Agents)
+	}
+	applyPlatformOverride(manifest.Services, deployPlatform)
+	if emuErr := checkEmulation(collectBuildPlatforms(manifest.Services)); emuErr != nil {
+		return emuErr
+	}
+	if buildErr := buildServiceImages(manifestDir, manifest.Name, manifest.Services); buildErr != nil {
+		return buildErr
 	}
 
 	// Push built images to registry
@@ -269,6 +297,38 @@ func waitForDeployment(ctx context.Context, client *EngineClient, appName string
 	}
 }
 
+// applyPlatformOverride sets Platform on every build service to the given value.
+// Used by the global --platform flag; wins over per-service platform:.
+func applyPlatformOverride(services map[string]types.ManifestService, platform string) {
+	if platform == "" {
+		return
+	}
+	for name, svc := range services { //nolint:gocritic // map iteration
+		if svc.Build == nil {
+			continue
+		}
+		svc.Platform = platform
+		services[name] = svc
+	}
+}
+
+// collectBuildPlatforms returns the distinct platform strings across all build
+// services (skipping empty ones). Used for the emulation preflight.
+func collectBuildPlatforms(services map[string]types.ManifestService) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, svc := range services { //nolint:gocritic // map iteration
+		if svc.Build == nil || svc.Platform == "" {
+			continue
+		}
+		if !seen[svc.Platform] {
+			seen[svc.Platform] = true
+			out = append(out, svc.Platform)
+		}
+	}
+	return out
+}
+
 // buildServiceImages builds Docker images for services that have a build config.
 func buildServiceImages(manifestDir, appName string, services map[string]types.ManifestService) error {
 	needsBuild := false
@@ -302,7 +362,7 @@ func buildServiceImages(manifestDir, appName string, services map[string]types.M
 		}
 
 		logging.Info("Building image", "service", name, "image", imageName)
-		if err := buildImageFunc(imageName, contextPath, svc.Build.Dockerfile); err != nil {
+		if err := buildImageFunc(imageName, contextPath, svc.Build.Dockerfile, svc.Platform); err != nil {
 			return fmt.Errorf("failed to build image for service %q: %w", name, err)
 		}
 	}
@@ -311,12 +371,8 @@ func buildServiceImages(manifestDir, appName string, services map[string]types.M
 	return nil
 }
 
-func buildImage(imageName, contextPath, dockerfile string) error {
-	args := []string{"build", "-t", imageName}
-	if dockerfile != "" {
-		args = append(args, "-f", filepath.Join(contextPath, dockerfile))
-	}
-	args = append(args, contextPath)
+func buildImage(imageName, contextPath, dockerfile, platform string) error {
+	args := buildImageArgs(imageName, contextPath, dockerfile, platform)
 
 	buildCmd := exec.Command("nerdctl", args...)
 	buildCmd.Stdout = os.Stdout
@@ -361,7 +417,7 @@ func pushServiceImages(registryURL string, services map[string]types.ManifestSer
 		}
 
 		logging.Info("Pushing image", "image", registryImage)
-		if err := pushImageFunc(registryImage); err != nil {
+		if err := pushImageFunc(registryImage, svc.Platform != ""); err != nil {
 			return fmt.Errorf("failed to push image for service %q: %w", name, err)
 		}
 
@@ -384,8 +440,18 @@ func tagImage(src, dst string) error {
 	return nil
 }
 
-func pushImage(image string) error {
-	cmd := exec.Command("nerdctl", "push", "--insecure-registry", image)
+// pushImageArgs constructs nerdctl push arguments. allPlatforms pushes the full
+// multi-arch image index (needed when the image was built for a non-host arch).
+func pushImageArgs(image string, allPlatforms bool) []string {
+	args := []string{"push", "--insecure-registry"}
+	if allPlatforms {
+		args = append(args, "--all-platforms")
+	}
+	return append(args, image)
+}
+
+func pushImage(image string, allPlatforms bool) error {
+	cmd := exec.Command("nerdctl", pushImageArgs(image, allPlatforms)...) //nolint:gosec // args are constructed internally
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/cmd/banyan-cli/cmd/deploy.go
+++ b/cmd/banyan-cli/cmd/deploy.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -259,8 +260,17 @@ func waitForDeployment(ctx context.Context, client *EngineClient, appName string
 	for {
 		select {
 		case <-ctx.Done():
-			logging.Warn("Timeout waiting for deployment")
-			return fmt.Errorf("deployment timed out")
+			// A deadline here means we stopped waiting, NOT that the deployment
+			// failed — the engine keeps working on it asynchronously. Report it
+			// as progress info (exit 0) so it doesn't read as an error.
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				logging.Info("Still deploying — stopped waiting, the engine is finishing this in the background",
+					"name", appName,
+					"hint", "check status with 'banyan-cli deployment' or 'banyan-cli logs <container>'")
+				return nil
+			}
+			// Cancelled/interrupted (e.g. Ctrl-C) — propagate.
+			return ctx.Err()
 		case <-ticker.C:
 			status, err := client.Status(ctx)
 			if err != nil {

--- a/cmd/banyan-cli/cmd/deploy_test.go
+++ b/cmd/banyan-cli/cmd/deploy_test.go
@@ -107,32 +107,42 @@ func TestValidateServiceArgs(t *testing.T) {
 }
 
 func TestBuildImageArgs(t *testing.T) {
-	t.Run("without dockerfile", func(t *testing.T) {
-		args := buildImageArgs("my-app:latest", "./web", "")
+	t.Run("without dockerfile, no platform", func(t *testing.T) {
+		args := buildImageArgs("my-app:latest", "./web", "", "")
 		expected := []string{"build", "-t", "my-app:latest", "./web"}
-		if len(args) != len(expected) {
-			t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
-		}
-		for i, exp := range expected {
-			if args[i] != exp {
-				t.Errorf("arg[%d]: expected %q, got %q", i, exp, args[i])
-			}
-		}
+		assertArgs(t, expected, args)
 	})
 
-	t.Run("with dockerfile", func(t *testing.T) {
-		args := buildImageArgs("my-app:latest", "./web", "Dockerfile.prod")
+	t.Run("with dockerfile, no platform", func(t *testing.T) {
+		args := buildImageArgs("my-app:latest", "./web", "Dockerfile.prod", "")
 		expectedPath := filepath.Join("./web", "Dockerfile.prod")
 		expected := []string{"build", "-t", "my-app:latest", "-f", expectedPath, "./web"}
-		if len(args) != len(expected) {
-			t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
-		}
-		for i, exp := range expected {
-			if args[i] != exp {
-				t.Errorf("arg[%d]: expected %q, got %q", i, exp, args[i])
-			}
-		}
+		assertArgs(t, expected, args)
 	})
+
+	t.Run("with platform", func(t *testing.T) {
+		args := buildImageArgs("my-app:latest", "./web", "", "linux/arm64")
+		expected := []string{"build", "-t", "my-app:latest", "--platform", "linux/arm64", "./web"}
+		assertArgs(t, expected, args)
+	})
+
+	t.Run("with multiple platforms", func(t *testing.T) {
+		args := buildImageArgs("my-app:latest", "./web", "", "linux/amd64,linux/arm64")
+		expected := []string{"build", "-t", "my-app:latest", "--platform", "linux/amd64,linux/arm64", "./web"}
+		assertArgs(t, expected, args)
+	})
+}
+
+func assertArgs(t *testing.T, expected, args []string) {
+	t.Helper()
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, exp := range expected {
+		if args[i] != exp {
+			t.Errorf("arg[%d]: expected %q, got %q", i, exp, args[i])
+		}
+	}
 }
 
 func TestBuildServiceImages_NoBuildNeeded(t *testing.T) {
@@ -245,7 +255,7 @@ func TestBuildServiceImages_WithBuild(t *testing.T) {
 	t.Cleanup(func() { buildImageFunc = origBuildImageFunc })
 
 	var calls []string
-	buildImageFunc = func(imageName, contextPath, dockerfile string) error {
+	buildImageFunc = func(imageName, contextPath, dockerfile, platform string) error {
 		calls = append(calls, imageName)
 		return nil
 	}
@@ -275,7 +285,7 @@ func TestBuildServiceImages_BuildFails(t *testing.T) {
 	origBuildImageFunc := buildImageFunc
 	t.Cleanup(func() { buildImageFunc = origBuildImageFunc })
 
-	buildImageFunc = func(imageName, contextPath, dockerfile string) error {
+	buildImageFunc = func(imageName, contextPath, dockerfile, platform string) error {
 		return fmt.Errorf("build failed")
 	}
 
@@ -299,7 +309,7 @@ func TestBuildServiceImages_SetsDefaultImage(t *testing.T) {
 	origBuildImageFunc := buildImageFunc
 	t.Cleanup(func() { buildImageFunc = origBuildImageFunc })
 
-	buildImageFunc = func(imageName, contextPath, dockerfile string) error {
+	buildImageFunc = func(imageName, contextPath, dockerfile, platform string) error {
 		return nil
 	}
 
@@ -333,7 +343,7 @@ func TestPushServiceImages_WithBuild(t *testing.T) {
 		tagCalls = append(tagCalls, [2]string{src, dst})
 		return nil
 	}
-	pushImageFunc = func(image string) error {
+	pushImageFunc = func(image string, allPlatforms bool) error {
 		pushCalls = append(pushCalls, image)
 		return nil
 	}
@@ -384,7 +394,7 @@ func TestPushServiceImages_TagFails(t *testing.T) {
 	tagImageFunc = func(src, dst string) error {
 		return fmt.Errorf("tag failed")
 	}
-	pushImageFunc = func(image string) error {
+	pushImageFunc = func(image string, allPlatforms bool) error {
 		t.Error("push should not be called when tag fails")
 		return nil
 	}
@@ -416,7 +426,7 @@ func TestPushServiceImages_PushFails(t *testing.T) {
 	tagImageFunc = func(src, dst string) error {
 		return nil
 	}
-	pushImageFunc = func(image string) error {
+	pushImageFunc = func(image string, allPlatforms bool) error {
 		return fmt.Errorf("push failed")
 	}
 
@@ -823,4 +833,48 @@ func TestRunDeploy_WithServiceArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
+}
+
+func TestApplyPlatformOverride(t *testing.T) {
+	services := map[string]types.ManifestService{
+		"web": {Build: &types.ManifestBuild{Context: "./web"}},
+		"api": {Build: &types.ManifestBuild{Context: "./api"}, Platform: "linux/amd64"},
+		"db":  {Image: "mysql:8.0"}, // no build — untouched
+	}
+	applyPlatformOverride(services, "linux/arm64")
+	if services["web"].Platform != "linux/arm64" {
+		t.Errorf("web: override should set empty platform, got %q", services["web"].Platform)
+	}
+	if services["api"].Platform != "linux/arm64" {
+		t.Errorf("api: global flag should win over per-service, got %q", services["api"].Platform)
+	}
+	if services["db"].Platform != "" {
+		t.Errorf("db: non-build service must be untouched, got %q", services["db"].Platform)
+	}
+}
+
+func TestCollectBuildPlatforms(t *testing.T) {
+	services := map[string]types.ManifestService{
+		"web": {Build: &types.ManifestBuild{Context: "./web"}, Platform: "linux/arm64"},
+		"api": {Build: &types.ManifestBuild{Context: "./api"}}, // no platform
+		"db":  {Image: "mysql:8.0", Platform: "linux/arm64"},   // no build — ignored
+	}
+	got := collectBuildPlatforms(services)
+	if len(got) != 1 || got[0] != "linux/arm64" {
+		t.Errorf("expected [linux/arm64], got %v", got)
+	}
+}
+
+func TestPushImageArgs(t *testing.T) {
+	t.Run("single host arch", func(t *testing.T) {
+		args := pushImageArgs("reg:5000/app:latest", false)
+		expected := []string{"push", "--insecure-registry", "reg:5000/app:latest"}
+		assertArgs(t, expected, args)
+	})
+
+	t.Run("all platforms", func(t *testing.T) {
+		args := pushImageArgs("reg:5000/app:latest", true)
+		expected := []string{"push", "--insecure-registry", "--all-platforms", "reg:5000/app:latest"}
+		assertArgs(t, expected, args)
+	})
 }

--- a/cmd/banyan-cli/cmd/deploy_test.go
+++ b/cmd/banyan-cli/cmd/deploy_test.go
@@ -726,12 +726,11 @@ func TestWaitForDeployment_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
+	// A wait timeout is not a failure — the engine keeps deploying in the
+	// background — so waitForDeployment returns nil (informational, exit 0).
 	err := waitForDeployment(ctx, client, "my-app")
-	if err == nil {
-		t.Fatal("expected timeout error")
-	}
-	if !strings.Contains(err.Error(), "timed out") {
-		t.Errorf("unexpected error: %v", err)
+	if err != nil {
+		t.Errorf("expected nil on wait timeout (deployment continues on engine), got: %v", err)
 	}
 }
 
@@ -740,14 +739,15 @@ func TestWaitForDeployment_Deploying(t *testing.T) {
 	t.Cleanup(func() { deployTags = origTags })
 	deployTags = nil
 
-	// StatusDeploying should be logged but not returned — will eventually timeout
+	// StatusDeploying should be logged but not returned — will eventually hit the
+	// wait deadline, which returns nil (deployment still progressing on engine).
 	client := setupBufconnClientWithStatus(t, types.StatusDeploying)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	err := waitForDeployment(ctx, client, "my-app")
-	if err == nil {
-		t.Fatal("expected timeout error")
+	if err != nil {
+		t.Errorf("expected nil on wait timeout, got: %v", err)
 	}
 }
 

--- a/cmd/banyan-cli/cmd/platform.go
+++ b/cmd/banyan-cli/cmd/platform.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/fertile-org/banyan/pkg/logging"
+	"github.com/fertile-org/banyan/pkg/rpc/banyanpb"
+	"github.com/fertile-org/banyan/pkg/types"
+)
+
+// clusterArches builds a name→arch map (omitting agents that report no arch)
+// and the sorted set of distinct arches present in the cluster.
+func clusterArches(agents []*banyanpb.AgentInfo) (map[string]string, []string) {
+	archOf := map[string]string{}
+	set := map[string]bool{}
+	for _, a := range agents {
+		if a.Arch == "" {
+			continue
+		}
+		archOf[a.Name] = a.Arch
+		set[a.Arch] = true
+	}
+	var all []string
+	for arch := range set {
+		all = append(all, arch)
+	}
+	sort.Strings(all)
+	return archOf, all
+}
+
+// resolveServicePlatform returns the nerdctl --platform value for one build
+// service, applying the precedence rules. Returns "" to mean "build host arch"
+// (the caller's fallback), which also covers the unknown/offline cases.
+func resolveServicePlatform(svc types.ManifestService, archOf map[string]string, allArches []string) string { //nolint:gocritic // svc is a map-range copy; passing by value keeps call sites simple
+	// Rule 1: explicit platform wins.
+	if svc.Platform != "" {
+		return svc.Platform
+	}
+	// Rule 2: pinned to a node — use that node's arch (if known).
+	if svc.Deploy != nil && svc.Deploy.Placement != nil && svc.Deploy.Placement.Node != "" {
+		if arch, ok := archOf[svc.Deploy.Placement.Node]; ok {
+			return "linux/" + arch
+		}
+		return "" // unknown node arch → host fallback
+	}
+	// Rule 4: no placement constraint — union of all cluster arches.
+	// (Rule 3, tag-based union, is folded into "all" for now: without a tag
+	// filter we target every known arch, which is always safe.)
+	if len(allArches) == 0 {
+		return "" // no arch info at all → host fallback
+	}
+	var platforms []string
+	for _, a := range allArches {
+		platforms = append(platforms, "linux/"+a)
+	}
+	return strings.Join(platforms, ",")
+}
+
+// applyResolvedPlatforms fills Platform on every build service that does not
+// already have one, using cluster arch info. Services left empty fall back to
+// the build host arch; we warn so the operator knows why.
+func applyResolvedPlatforms(services map[string]types.ManifestService, agents []*banyanpb.AgentInfo) {
+	archOf, all := clusterArches(agents)
+	for name, svc := range services { //nolint:gocritic // map iteration
+		if svc.Build == nil || svc.Platform != "" {
+			continue
+		}
+		resolved := resolveServicePlatform(svc, archOf, all)
+		if resolved == "" {
+			logging.Warn("Could not determine target arch; building for host arch",
+				"service", name,
+				"hint", "upgrade agents to report arch, or set platform: on the service")
+			continue
+		}
+		svc.Platform = resolved
+		services[name] = svc
+	}
+}

--- a/cmd/banyan-cli/cmd/platform_test.go
+++ b/cmd/banyan-cli/cmd/platform_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/fertile-org/banyan/pkg/rpc/banyanpb"
+	"github.com/fertile-org/banyan/pkg/types"
+)
+
+func TestResolveServicePlatform(t *testing.T) {
+	archOf := map[string]string{
+		"node-amd": "amd64",
+		"node-arm": "arm64",
+	}
+	all := []string{"amd64", "arm64"}
+
+	tests := []struct {
+		name string
+		svc  types.ManifestService
+		want string
+	}{
+		{
+			name: "explicit platform wins",
+			svc:  types.ManifestService{Build: &types.ManifestBuild{Context: "."}, Platform: "linux/riscv64"},
+			want: "linux/riscv64",
+		},
+		{
+			name: "placement node arch",
+			svc:  types.ManifestService{Build: &types.ManifestBuild{Context: "."}, Deploy: &types.ManifestDeploy{Placement: &types.ManifestPlacement{Node: "node-arm"}}},
+			want: "linux/arm64",
+		},
+		{
+			name: "no constraint -> union of all cluster arches",
+			svc:  types.ManifestService{Build: &types.ManifestBuild{Context: "."}},
+			want: "linux/amd64,linux/arm64",
+		},
+		{
+			name: "placement to unknown node -> host fallback (empty)",
+			svc:  types.ManifestService{Build: &types.ManifestBuild{Context: "."}, Deploy: &types.ManifestDeploy{Placement: &types.ManifestPlacement{Node: "ghost"}}},
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveServicePlatform(tc.svc, archOf, all)
+			if normalizePlatforms(got) != normalizePlatforms(tc.want) {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// normalizePlatforms sorts a comma-list so order does not matter in assertions.
+func normalizePlatforms(p string) string {
+	if p == "" {
+		return ""
+	}
+	parts := strings.Split(p, ",")
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func TestClusterArches(t *testing.T) {
+	agents := []*fakeAgent{{name: "a", arch: "amd64"}, {name: "b", arch: "arm64"}, {name: "c", arch: ""}}
+	archOf, all := clusterArches(toAgentInfo(agents))
+	if archOf["a"] != "amd64" || archOf["b"] != "arm64" {
+		t.Errorf("archOf wrong: %v", archOf)
+	}
+	if _, ok := archOf["c"]; ok {
+		t.Error("empty-arch agent should be omitted from archOf")
+	}
+	if normalizePlatforms(strings.Join(all, ",")) != "amd64,arm64" {
+		t.Errorf("all arches wrong: %v", all)
+	}
+}
+
+type fakeAgent struct{ name, arch string }
+
+func toAgentInfo(fs []*fakeAgent) []*banyanpb.AgentInfo {
+	var out []*banyanpb.AgentInfo
+	for _, f := range fs {
+		out = append(out, &banyanpb.AgentInfo{Name: f.name, Arch: f.arch})
+	}
+	return out
+}

--- a/cmd/banyan-cli/cmd/preflight.go
+++ b/cmd/banyan-cli/cmd/preflight.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const binfmtDir = "/proc/sys/fs/binfmt_misc"
+
+// qemuCPUName maps a platform string (e.g. "linux/arm64" or "arm64") to the
+// QEMU user-static CPU name used in the binfmt_misc handler filename.
+func qemuCPUName(platform string) string {
+	arch := platform
+	if i := strings.LastIndex(platform, "/"); i >= 0 {
+		arch = platform[i+1:]
+	}
+	switch arch {
+	case "arm64", "aarch64":
+		return "aarch64"
+	case "amd64", "x86_64":
+		return "x86_64"
+	default:
+		return arch
+	}
+}
+
+// binfmtRegistered reports whether an enabled qemu-<cpu> handler exists under dir.
+func binfmtRegistered(dir, cpu string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "qemu-"+cpu))
+	if err != nil {
+		return false
+	}
+	// The handler file's first line is "enabled" or "disabled".
+	return strings.HasPrefix(strings.TrimSpace(string(data)), "enabled")
+}
+
+// hostCPU returns the QEMU CPU name for the machine running the CLI.
+func hostCPU() string {
+	return qemuCPUName(runtime.GOARCH)
+}
+
+// checkEmulation verifies that every non-host platform in platforms has a
+// registered QEMU binfmt handler. Returns an actionable error if not.
+func checkEmulation(platforms []string) error {
+	return checkEmulationIn(binfmtDir, platforms)
+}
+
+// checkEmulationIn is checkEmulation with an injectable binfmt dir (for tests).
+// Each entry may itself be a comma-separated multi-platform string
+// (e.g. "linux/amd64,linux/arm64"), so every sub-platform is checked.
+func checkEmulationIn(dir string, platforms []string) error {
+	host := hostCPU()
+	var missing []string
+	seen := map[string]bool{}
+	for _, entry := range platforms {
+		for _, p := range strings.Split(entry, ",") {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			cpu := qemuCPUName(p)
+			if cpu == host || seen[cpu] {
+				continue
+			}
+			seen[cpu] = true
+			if !binfmtRegistered(dir, cpu) {
+				missing = append(missing, cpu)
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"cross-arch build requires QEMU emulation for %s, but no binfmt handler is registered.\n"+
+			"Install it with either:\n"+
+			"  sudo bash install-deps.sh   # installs qemu-user-static + binfmt-support\n"+
+			"or:\n"+
+			"  sudo nerdctl run --privileged --rm tonistiigi/binfmt --install all",
+		strings.Join(missing, ", "))
+}

--- a/cmd/banyan-cli/cmd/preflight_test.go
+++ b/cmd/banyan-cli/cmd/preflight_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestQemuCPUName(t *testing.T) {
+	cases := map[string]string{
+		"linux/arm64": "aarch64",
+		"arm64":       "aarch64",
+		"linux/amd64": "x86_64",
+		"amd64":       "x86_64",
+	}
+	for platform, want := range cases {
+		if got := qemuCPUName(platform); got != want {
+			t.Errorf("qemuCPUName(%q) = %q, want %q", platform, got, want)
+		}
+	}
+}
+
+func TestBinfmtRegistered(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "qemu-aarch64"), []byte("enabled\ninterpreter /usr/bin/qemu-aarch64-static\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !binfmtRegistered(dir, "aarch64") {
+		t.Error("expected aarch64 to be registered")
+	}
+	if binfmtRegistered(dir, "x86_64") {
+		t.Error("expected x86_64 to be unregistered (no file)")
+	}
+}
+
+func TestBinfmtRegistered_DisabledHandler(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "qemu-aarch64"), []byte("disabled\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if binfmtRegistered(dir, "aarch64") {
+		t.Error("expected disabled handler to count as not registered")
+	}
+}
+
+func TestCheckEmulationIn(t *testing.T) {
+	host := hostCPU() // whatever arch the test runs on
+	// A registered dir with only the host handler present.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "qemu-"+host), []byte("enabled\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The non-host CPU name (the one that will be missing from dir).
+	foreign := "aarch64"
+	if host == "aarch64" {
+		foreign = "x86_64"
+	}
+	foreignArch := "arm64"
+	if foreign == "x86_64" {
+		foreignArch = "amd64"
+	}
+
+	t.Run("host-only platform passes", func(t *testing.T) {
+		if err := checkEmulationIn(dir, []string{"linux/" + archOfCPU(host)}); err != nil {
+			t.Errorf("expected nil (host arch needs no emulation), got %v", err)
+		}
+	})
+
+	t.Run("comma-joined multi-arch detects missing foreign handler", func(t *testing.T) {
+		// "<host>,<foreign>" — the foreign half must be caught even though the
+		// host half (and, on some hosts, its trailing position) would be skipped.
+		combo := "linux/" + archOfCPU(host) + ",linux/" + foreignArch
+		err := checkEmulationIn(dir, []string{combo})
+		if err == nil {
+			t.Fatalf("expected error for missing %s emulation, got nil", foreign)
+		}
+		if !strings.Contains(err.Error(), foreign) {
+			t.Errorf("error should name the missing CPU %q, got: %v", foreign, err)
+		}
+	})
+
+	t.Run("registered foreign handler passes", func(t *testing.T) {
+		if err := os.WriteFile(filepath.Join(dir, "qemu-"+foreign), []byte("enabled\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := checkEmulationIn(dir, []string{"linux/" + foreignArch}); err != nil {
+			t.Errorf("expected nil once %s is registered, got %v", foreign, err)
+		}
+	})
+}
+
+// archOfCPU maps a QEMU CPU name back to the Go arch name (inverse of qemuCPUName).
+func archOfCPU(cpu string) string {
+	switch cpu {
+	case "aarch64":
+		return "arm64"
+	case "x86_64":
+		return "amd64"
+	default:
+		return cpu
+	}
+}

--- a/docs/superpowers/plans/2026-07-07-install-sudo-secure-path-symlink.md
+++ b/docs/superpowers/plans/2026-07-07-install-sudo-secure-path-symlink.md
@@ -1,0 +1,339 @@
+# Installer secure_path symlink — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After install, `sudo banyan-{engine,agent,cli}` work out of the box on every supported OS by symlinking the three binaries from `/usr/local/bin` into `/usr/sbin` (which is on sudo's `secure_path` everywhere), without touching sudo config.
+
+**Architecture:** Add one shared helper `link_secure_path()` to `install-deps.sh` (sourced by both installers). It symlinks a named binary from `INSTALL_DIR` into `LINK_DIR` (default `/usr/sbin`), refusing to clobber a pre-existing real file. Each installer calls it after installing each banyan binary, and re-asserts `INSTALL_DIR`/`LINK_DIR` defaults locally so the entry scripts no longer depend implicitly on the sourced file.
+
+**Tech Stack:** Bash (`set -euo pipefail`), shellcheck, plain-bash unit test harness.
+
+Design spec: `docs/superpowers/specs/2026-07-07-install-sudo-secure-path-symlink-design.md`
+
+---
+
+## File structure
+
+- `install-deps.sh` — shared library. Owns `INSTALL_DIR`/`LINK_DIR` defaults and the new `link_secure_path()` helper. Safe to `source` (no top-level execution beyond var/function definitions).
+- `install.sh` — release-binary installer. Re-asserts defaults after sourcing; calls `link_secure_path` in `install_binary()`.
+- `install-from-source.sh` — build-from-source installer. Re-asserts defaults after sourcing; calls `link_secure_path` in `build_binary()`.
+- `test/os-compat/test-link-secure-path.sh` — new isolated unit test for `link_secure_path()` (no network, no root).
+
+---
+
+## Task 1: Add `LINK_DIR` + `link_secure_path()` helper to `install-deps.sh`
+
+**Files:**
+- Create: `test/os-compat/test-link-secure-path.sh`
+- Modify: `install-deps.sh:7` (add `LINK_DIR` after `INSTALL_DIR`) and after the output helpers (`fatal()` at `install-deps.sh:27`) to add the function
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/os-compat/test-link-secure-path.sh` with exactly this content:
+
+```bash
+#!/usr/bin/env bash
+# Unit tests for link_secure_path() in install-deps.sh.
+# Sources the library and exercises the function against temp dirs.
+# No network, no root required.
+#
+# Run: bash test/os-compat/test-link-secure-path.sh
+
+# NOTE: deliberately no `set -e` — some cases assert a command's exit code.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# install-deps.sh is a sourced library (only var/function definitions at top
+# level), so sourcing it here is safe.
+# shellcheck source=../../install-deps.sh
+source "${PROJECT_ROOT}/install-deps.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+WORK=""
+new_env() {
+    WORK=$(mktemp -d)
+    INSTALL_DIR="${WORK}/install"
+    LINK_DIR="${WORK}/link"
+    mkdir -p "$INSTALL_DIR" "$LINK_DIR"
+    : > "${INSTALL_DIR}/banyan-cli"
+    chmod +x "${INSTALL_DIR}/banyan-cli"
+}
+cleanup() { rm -rf "$WORK"; }
+
+# 1. Creates a symlink that resolves to INSTALL_DIR/<name>
+new_env
+link_secure_path banyan-cli >/dev/null 2>&1
+if [ -L "${LINK_DIR}/banyan-cli" ] && \
+   [ "$(readlink "${LINK_DIR}/banyan-cli")" = "${INSTALL_DIR}/banyan-cli" ]; then
+    pass "creates symlink to INSTALL_DIR"
+else
+    fail "creates symlink to INSTALL_DIR"
+fi
+cleanup
+
+# 2. Idempotent — second call keeps a correct symlink and returns 0
+new_env
+link_secure_path banyan-cli >/dev/null 2>&1
+link_secure_path banyan-cli >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && \
+   [ "$(readlink "${LINK_DIR}/banyan-cli")" = "${INSTALL_DIR}/banyan-cli" ]; then
+    pass "idempotent on repeat call"
+else
+    fail "idempotent on repeat call"
+fi
+cleanup
+
+# 3. Self-link guard — LINK_DIR == INSTALL_DIR must not replace the real file
+new_env
+LINK_DIR="$INSTALL_DIR"
+link_secure_path banyan-cli >/dev/null 2>&1
+if [ -f "${INSTALL_DIR}/banyan-cli" ] && [ ! -L "${INSTALL_DIR}/banyan-cli" ]; then
+    pass "self-link guard leaves file untouched"
+else
+    fail "self-link guard leaves file untouched"
+fi
+cleanup
+
+# 4. Missing-dir guard — absent LINK_DIR is a no-op and returns 0
+new_env
+rm -rf "$LINK_DIR"
+link_secure_path banyan-cli >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -e "${LINK_DIR}/banyan-cli" ]; then
+    pass "missing-dir guard is a no-op"
+else
+    fail "missing-dir guard is a no-op"
+fi
+cleanup
+
+# 5. Real-file guard — a pre-existing regular file is left intact
+new_env
+echo "real" > "${LINK_DIR}/banyan-cli"
+link_secure_path banyan-cli >/dev/null 2>&1
+if [ ! -L "${LINK_DIR}/banyan-cli" ] && \
+   [ "$(cat "${LINK_DIR}/banyan-cli")" = "real" ]; then
+    pass "real-file guard leaves file intact"
+else
+    fail "real-file guard leaves file intact"
+fi
+cleanup
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]
+```
+
+Make it executable:
+
+```bash
+chmod +x test/os-compat/test-link-secure-path.sh
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash test/os-compat/test-link-secure-path.sh`
+Expected: FAIL — every case fails because `link_secure_path` is not defined yet (bash prints `link_secure_path: command not found` and the assertions fail), ending with a non-zero `Results: 0 passed, 5 failed`.
+
+- [ ] **Step 3: Add `LINK_DIR` default in `install-deps.sh`**
+
+In `install-deps.sh`, right after line 7 (`INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"`), add:
+
+```bash
+# Directory on sudo's secure_path where the banyan commands are exposed via
+# symlink, so `sudo banyan-*` resolves even when INSTALL_DIR (e.g.
+# /usr/local/bin) is not on sudo's secure_path (default on RHEL/Oracle/Fedora).
+LINK_DIR="${LINK_DIR:-/usr/sbin}"
+```
+
+- [ ] **Step 4: Add the `link_secure_path()` helper**
+
+In `install-deps.sh`, immediately after the output-helpers block (after `fatal() { error "$*"; exit 1; }` at line 27), add:
+
+```bash
+
+# link_secure_path exposes an installed binary on sudo's secure_path by
+# symlinking it from INSTALL_DIR into LINK_DIR (default /usr/sbin). On RHEL/
+# Oracle/Fedora, sudo's secure_path excludes /usr/local/bin, so `sudo banyan-*`
+# fails with command-not-found even though the binary is installed. /usr/sbin
+# and /usr/bin are on the default secure_path of every supported OS.
+#
+# It never clobbers a real file: if LINK_DIR/<name> already exists as a regular
+# file (distro package, user-placed), it is left untouched with a warning. An
+# existing symlink (ours) is refreshed idempotently.
+link_secure_path() {
+    local name=$1
+    [ "$LINK_DIR" = "$INSTALL_DIR" ] && return 0   # avoid self-referential link
+    [ -d "$LINK_DIR" ] || return 0                 # skip if target dir absent
+    local target="${LINK_DIR}/${name}"
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+        warn "${target} is a real file — skipping symlink; use ${INSTALL_DIR}/${name} or the full path"
+        return 0
+    fi
+    ln -sf "${INSTALL_DIR}/${name}" "$target"
+    info "Linked ${target} -> ${INSTALL_DIR}/${name} (so 'sudo ${name}' works)"
+}
+```
+
+Note: the success `info` line lives inside the helper (not in callers) so both installers report it consistently (DRY).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash test/os-compat/test-link-secure-path.sh`
+Expected: PASS — `Results: 5 passed, 0 failed`, exit code 0.
+
+- [ ] **Step 6: Lint**
+
+Run: `shellcheck install-deps.sh test/os-compat/test-link-secure-path.sh`
+Expected: no new warnings. (Pre-existing SC1091 "not following sourced file" on the test's `source` line is acceptable — it is a dynamic path; the `# shellcheck source=` directive should suppress it.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add install-deps.sh test/os-compat/test-link-secure-path.sh
+git commit -m "feat(install): add link_secure_path helper to expose banyan on sudo secure_path"
+```
+
+---
+
+## Task 2: Wire `link_secure_path` into `install.sh` + explicit defaults
+
+**Files:**
+- Modify: `install.sh` after the source block (`install.sh:45`) and inside `install_binary()` (after `install.sh:110`)
+
+- [ ] **Step 1: Re-assert defaults after sourcing**
+
+In `install.sh`, immediately after line 45 (`[ -n "$DEPS_TMP" ] && rm -f "$DEPS_TMP"`), add:
+
+```bash
+
+# INSTALL_DIR / LINK_DIR are provided by install-deps.sh; re-assert defaults
+# here so this script is correct on its own even if sourcing is reordered.
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+LINK_DIR="${LINK_DIR:-/usr/sbin}"
+```
+
+- [ ] **Step 2: Call the helper in `install_binary()`**
+
+In `install.sh`, inside `install_binary()`, the tail currently reads (lines 107-111):
+
+```bash
+    chmod +x "$tmp"
+    mv "$tmp" "${INSTALL_DIR}/${name}"
+
+    info "${name} ${BANYAN_VERSION} installed to ${INSTALL_DIR}/${name}"
+}
+```
+
+Change it to:
+
+```bash
+    chmod +x "$tmp"
+    mv "$tmp" "${INSTALL_DIR}/${name}"
+
+    info "${name} ${BANYAN_VERSION} installed to ${INSTALL_DIR}/${name}"
+    link_secure_path "$name"
+}
+```
+
+- [ ] **Step 3: Syntax check**
+
+Run: `bash -n install.sh`
+Expected: no output, exit code 0 (valid syntax).
+
+- [ ] **Step 4: Confirm the wiring is present and correctly placed**
+
+Run: `grep -n 'link_secure_path\|LINK_DIR' install.sh`
+Expected: shows the `LINK_DIR` re-assert line and the `link_secure_path "$name"` call inside `install_binary()`.
+
+- [ ] **Step 5: Lint**
+
+Run: `shellcheck install.sh`
+Expected: no new warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add install.sh
+git commit -m "feat(install): symlink banyan binaries onto secure_path in install.sh"
+```
+
+---
+
+## Task 3: Wire `link_secure_path` into `install-from-source.sh` + explicit defaults
+
+**Files:**
+- Modify: `install-from-source.sh` after the source block (`install-from-source.sh:42`) and inside `build_binary()` (after `install-from-source.sh:67`)
+
+- [ ] **Step 1: Re-assert defaults after sourcing**
+
+In `install-from-source.sh`, immediately after line 42 (`[ -n "$DEPS_TMP" ] && rm -f "$DEPS_TMP"`), add:
+
+```bash
+
+# INSTALL_DIR / LINK_DIR are provided by install-deps.sh; re-assert defaults
+# here so this script is correct on its own even if sourcing is reordered.
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+LINK_DIR="${LINK_DIR:-/usr/sbin}"
+```
+
+- [ ] **Step 2: Call the helper in `build_binary()`**
+
+In `install-from-source.sh`, inside `build_binary()`, the tail currently reads (lines 65-68):
+
+```bash
+    chmod +x "$tmp"
+    mv "$tmp" "${INSTALL_DIR}/${name}"
+
+    info "${name} installed to ${INSTALL_DIR}/${name} (built from source)"
+}
+```
+
+Change it to:
+
+```bash
+    chmod +x "$tmp"
+    mv "$tmp" "${INSTALL_DIR}/${name}"
+
+    info "${name} installed to ${INSTALL_DIR}/${name} (built from source)"
+    link_secure_path "$name"
+}
+```
+
+- [ ] **Step 3: Syntax check**
+
+Run: `bash -n install-from-source.sh`
+Expected: no output, exit code 0.
+
+- [ ] **Step 4: Confirm the wiring is present and correctly placed**
+
+Run: `grep -n 'link_secure_path\|LINK_DIR' install-from-source.sh`
+Expected: shows the `LINK_DIR` re-assert line and the `link_secure_path "$name"` call inside `build_binary()`.
+
+- [ ] **Step 5: Lint**
+
+Run: `shellcheck install-from-source.sh`
+Expected: no new warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add install-from-source.sh
+git commit -m "feat(install): symlink banyan binaries onto secure_path in install-from-source.sh"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Design §1 (LINK_DIR + helper) → Task 1. §2 (call after each binary) → Tasks 2 & 3. §3 (explicit defaults) → Tasks 2 & 3 Step 1. Testing (5 cases + shellcheck) → Task 1 Steps 1/5/6 + `bash -n`/shellcheck in Tasks 2/3.
+- **No placeholders:** all steps show exact code/commands and expected output.
+- **Type/name consistency:** helper is `link_secure_path`, vars `INSTALL_DIR`/`LINK_DIR`, everywhere.
+- **Deviation from spec (intentional):** the success `info` line is emitted inside `link_secure_path` rather than by each caller — DRY, keeps caller sites to a single `link_secure_path "$name"` line. Behavior is unchanged.
+```

--- a/docs/superpowers/plans/2026-07-24-banyan-cli-multiarch-build.md
+++ b/docs/superpowers/plans/2026-07-24-banyan-cli-multiarch-build.md
@@ -1,0 +1,1393 @@
+# banyan-cli multi-arch build Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `banyan-cli up` build container images for the architecture(s) the target agents actually run, so `build:` services work on a mixed-arch (amd64/arm64) cluster without hand-run cross-build scripts.
+
+**Architecture:** Two phases. Phase 1 adds a per-service `platform:` field + a global `--platform` flag + a QEMU-binfmt preflight check, so cross-arch builds work by manual declaration. Phase 2 makes agents report `runtime.GOARCH` at registration, stores it on the engine, exposes it via the status API, and lets the CLI auto-resolve each service's build platform from the target agents' arch. A single multi-arch OCI image index (`nerdctl build --platform=... ` + `push --all-platforms`) means the engine/scheduler need no changes — containerd on the agent selects the right arch at pull time.
+
+**Tech Stack:** Go, cobra CLI, gRPC/protobuf (protoc via `make proto`), containerd + nerdctl + BuildKit, QEMU `binfmt_misc`, bash installer.
+
+> **IMPORTANT — no commits.** The user has instructed: do not commit anything, anywhere. Every task below ends with a **build+test verification** step instead of a `git commit`. Do not run `git add`/`git commit` at any point.
+
+> **Convention note:** All `banyan-cli` commands on the build box run under `sudo` (rootful containerd/buildkit). Go unit tests do **not** need sudo. Run Go commands from the module that owns the file: CLI code lives in the `banyan-cli` submodule (`cd cmd/banyan-cli`), engine/agent/types in the root module (this is a Go workspace, `go.work`). When unsure, run `go test ./...` from repo root — the workspace resolves both.
+
+---
+
+## File Structure
+
+**Phase 1 (manual declaration + preflight):**
+- `pkg/types/manifest.go` — add `Platform` field to `ManifestService` (root module).
+- `cmd/banyan-cli/cmd/deploy.go` — thread `platform` through build/push; add `--platform` flag; wire preflight.
+- `cmd/banyan-cli/cmd/preflight.go` *(new)* — QEMU binfmt detection + actionable error.
+- `cmd/banyan-cli/cmd/preflight_test.go` *(new)* — unit tests for binfmt detection.
+- `cmd/banyan-cli/cmd/deploy_test.go` — extend `buildImageArgs` / build-resolution tests.
+- `install-deps.sh` — add `install_qemu_binfmt()`, call it where buildkit is installed.
+
+**Phase 2 (auto-detect arch):**
+- `pkg/rpc/proto/banyan/v1/engine.proto` — `arch` field on `RegisterRequest` and `AgentInfo`.
+- `pkg/rpc/banyanpb/*.pb.go` — regenerated (via `make proto`), not hand-edited.
+- `pkg/agent/engine_client.go` — send `runtime.GOARCH` in Register.
+- `pkg/types/records.go` — `Arch` on `NodeRecord`.
+- `pkg/engine/grpc_handlers_agent.go` — persist `req.Arch`.
+- `pkg/engine/grpc_handlers_cli.go` — return `node.Arch` in `AgentInfo`.
+- `cmd/banyan-cli/cmd/platform.go` *(new)* — per-service platform resolution logic (pure, testable).
+- `cmd/banyan-cli/cmd/platform_test.go` *(new)* — resolution-rule table tests.
+- `cmd/banyan-cli/cmd/deploy.go` — reorder `runDeploy` to fetch agents before building; apply resolution.
+
+---
+
+# PHASE 1 — Manual declaration + preflight
+
+## Task 1: Add `Platform` field to `ManifestService`
+
+**Files:**
+- Modify: `pkg/types/manifest.go:113-127`
+- Test: `pkg/types/manifest_test.go` (create if absent, else append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/types/manifest_test.go` (create the file with this package header if it does not exist):
+
+```go
+package types
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestManifestService_PlatformParses(t *testing.T) {
+	src := `
+image: myimg:latest
+platform: linux/arm64
+`
+	var svc ManifestService
+	if err := yaml.Unmarshal([]byte(src), &svc); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if svc.Platform != "linux/arm64" {
+		t.Errorf("expected platform linux/arm64, got %q", svc.Platform)
+	}
+}
+
+func TestManifestService_PlatformOmittedIsEmpty(t *testing.T) {
+	var svc ManifestService
+	if err := yaml.Unmarshal([]byte("image: myimg:latest\n"), &svc); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if svc.Platform != "" {
+		t.Errorf("expected empty platform, got %q", svc.Platform)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/work/freelancer/banyan && go test ./pkg/types/ -run TestManifestService_Platform -v`
+Expected: FAIL — `svc.Platform undefined (type ManifestService has no field or method Platform)`.
+
+- [ ] **Step 3: Add the field**
+
+In `pkg/types/manifest.go`, add `Platform` to the `ManifestService` struct (place it right after `Build`):
+
+```go
+type ManifestService struct {
+	Image       string               `yaml:"image"`
+	Build       *ManifestBuild       `yaml:"build,omitempty"`
+	Platform    string               `yaml:"platform,omitempty"` // e.g., "linux/arm64"; empty = build host arch (or auto-detect)
+	Deploy      *ManifestDeploy      `yaml:"deploy,omitempty"`
+	Healthcheck *ManifestHealthcheck `yaml:"healthcheck,omitempty"`
+	Ports       []string             `yaml:"ports,omitempty"`
+	Environment []string             `yaml:"environment,omitempty"`
+	EnvFile     EnvFile              `yaml:"env_file,omitempty"`
+	Command     []string             `yaml:"command,omitempty"`
+	DependsOn   DependsOnConfig      `yaml:"depends_on,omitempty"`
+	Restart     string               `yaml:"restart,omitempty"`
+	Entrypoint  ShellCommand         `yaml:"entrypoint,omitempty"`
+	Volumes     VolumeMounts         `yaml:"volumes,omitempty"`
+	Secrets     []string             `yaml:"secrets,omitempty"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/work/freelancer/banyan && go test ./pkg/types/ -run TestManifestService_Platform -v`
+Expected: PASS (both subtests).
+
+- [ ] **Step 5: Verify the module still builds**
+
+Run: `cd /home/work/freelancer/banyan && go build ./pkg/types/`
+Expected: no output, exit 0. (No commit — per no-commit instruction.)
+
+---
+
+## Task 2: Thread `platform` through `buildImageArgs` and `buildImage`
+
+**Files:**
+- Modify: `cmd/banyan-cli/cmd/deploy.go:107-115` (`buildImageArgs`), `:314-328` (`buildImage`), `:24-28` (`buildImageFunc` var signature)
+- Test: `cmd/banyan-cli/cmd/deploy_test.go:109-137` (extend `TestBuildImageArgs`)
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the whole `func TestBuildImageArgs` in `cmd/banyan-cli/cmd/deploy_test.go` with:
+
+```go
+func TestBuildImageArgs(t *testing.T) {
+	t.Run("without dockerfile, no platform", func(t *testing.T) {
+		args := buildImageArgs("my-app:latest", "./web", "", "")
+		expected := []string{"build", "-t", "my-app:latest", "./web"}
+		assertArgs(t, expected, args)
+	})
+
+	t.Run("with dockerfile, no platform", func(t *testing.T) {
+		args := buildImageArgs("my-app:latest", "./web", "Dockerfile.prod", "")
+		expectedPath := filepath.Join("./web", "Dockerfile.prod")
+		expected := []string{"build", "-t", "my-app:latest", "-f", expectedPath, "./web"}
+		assertArgs(t, expected, args)
+	})
+
+	t.Run("with platform", func(t *testing.T) {
+		args := buildImageArgs("my-app:latest", "./web", "", "linux/arm64")
+		expected := []string{"build", "-t", "my-app:latest", "--platform", "linux/arm64", "./web"}
+		assertArgs(t, expected, args)
+	})
+
+	t.Run("with multiple platforms", func(t *testing.T) {
+		args := buildImageArgs("my-app:latest", "./web", "", "linux/amd64,linux/arm64")
+		expected := []string{"build", "-t", "my-app:latest", "--platform", "linux/amd64,linux/arm64", "./web"}
+		assertArgs(t, expected, args)
+	})
+}
+
+func assertArgs(t *testing.T, expected, args []string) {
+	t.Helper()
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, exp := range expected {
+		if args[i] != exp {
+			t.Errorf("arg[%d]: expected %q, got %q", i, exp, args[i])
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run TestBuildImageArgs -v`
+Expected: FAIL — `too many arguments in call to buildImageArgs` (compile error).
+
+- [ ] **Step 3: Update `buildImageArgs`, `buildImage`, and the func var**
+
+In `cmd/banyan-cli/cmd/deploy.go`, change `buildImageArgs` (currently line 108):
+
+```go
+// buildImageArgs constructs nerdctl build arguments.
+func buildImageArgs(imageName, contextPath, dockerfile, platform string) []string {
+	args := []string{"build", "-t", imageName}
+	if dockerfile != "" {
+		args = append(args, "-f", filepath.Join(contextPath, dockerfile))
+	}
+	if platform != "" {
+		args = append(args, "--platform", platform)
+	}
+	args = append(args, contextPath)
+	return args
+}
+```
+
+Change `buildImage` (currently line 314) to take `platform` and delegate to `buildImageArgs` (removing the duplicated arg-building):
+
+```go
+func buildImage(imageName, contextPath, dockerfile, platform string) error {
+	args := buildImageArgs(imageName, contextPath, dockerfile, platform)
+
+	buildCmd := exec.Command("nerdctl", args...)
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+	if err := buildCmd.Run(); err != nil {
+		return fmt.Errorf("nerdctl build failed (is buildkitd running?): %w", err)
+	}
+	return nil
+}
+```
+
+Change the func var declaration (currently line 25):
+
+```go
+var (
+	buildImageFunc = buildImage
+	tagImageFunc   = tagImage
+	pushImageFunc  = pushImage
+)
+```
+
+The type of `buildImageFunc` is inferred from `buildImage`, so its new signature `func(imageName, contextPath, dockerfile, platform string) error` propagates automatically.
+
+- [ ] **Step 4: Fix the caller in `buildServiceImages` and the test mocks (compile only)**
+
+In `cmd/banyan-cli/cmd/deploy.go`, `buildServiceImages` currently calls (line ~305) `buildImageFunc(imageName, contextPath, svc.Build.Dockerfile)`. Change it to pass the service platform:
+
+```go
+		logging.Info("Building image", "service", name, "image", imageName)
+		if err := buildImageFunc(imageName, contextPath, svc.Build.Dockerfile, svc.Platform); err != nil {
+			return fmt.Errorf("failed to build image for service %q: %w", name, err)
+		}
+```
+
+In `cmd/banyan-cli/cmd/deploy_test.go`, every mock assignment `buildImageFunc = func(imageName, contextPath, dockerfile string) error {` (there are three — around lines 248, 278, 302) must gain the `platform string` param:
+
+```go
+	buildImageFunc = func(imageName, contextPath, dockerfile, platform string) error {
+```
+
+(Do not change the mock bodies.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run 'TestBuildImageArgs|TestBuildServiceImages' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Verify the whole CLI module builds and its tests pass**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go build ./... && go test ./cmd/`
+Expected: build clean; tests PASS.
+
+---
+
+## Task 3: Push a multi-platform index when a service was built for non-host arch
+
+**Files:**
+- Modify: `cmd/banyan-cli/cmd/deploy.go:388-398` (`pushImage`) and its func var + the `pushServiceImages` caller
+- Test: `cmd/banyan-cli/cmd/deploy_test.go` (append `TestPushImageArgs`)
+
+Rationale: `nerdctl push --all-platforms` uploads every arch in the local image index. When a service declares `platform:` with a comma (multi-arch) — or any non-host platform — we must push `--all-platforms` or the agent's arch layer never reaches the registry.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/banyan-cli/cmd/deploy_test.go`:
+
+```go
+func TestPushImageArgs(t *testing.T) {
+	t.Run("single host arch", func(t *testing.T) {
+		args := pushImageArgs("reg:5000/app:latest", false)
+		expected := []string{"push", "--insecure-registry", "reg:5000/app:latest"}
+		assertArgs(t, expected, args)
+	})
+
+	t.Run("all platforms", func(t *testing.T) {
+		args := pushImageArgs("reg:5000/app:latest", true)
+		expected := []string{"push", "--insecure-registry", "--all-platforms", "reg:5000/app:latest"}
+		assertArgs(t, expected, args)
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run TestPushImageArgs -v`
+Expected: FAIL — `undefined: pushImageArgs`.
+
+- [ ] **Step 3: Extract `pushImageArgs` and thread `allPlatforms`**
+
+In `cmd/banyan-cli/cmd/deploy.go`, replace `pushImage` (currently line ~388) with:
+
+```go
+// pushImageArgs constructs nerdctl push arguments. allPlatforms pushes the full
+// multi-arch image index (needed when the image was built for a non-host arch).
+func pushImageArgs(image string, allPlatforms bool) []string {
+	args := []string{"push", "--insecure-registry"}
+	if allPlatforms {
+		args = append(args, "--all-platforms")
+	}
+	return append(args, image)
+}
+
+func pushImage(image string, allPlatforms bool) error {
+	cmd := exec.Command("nerdctl", pushImageArgs(image, allPlatforms)...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("nerdctl push failed: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Update the `pushServiceImages` caller and the mock**
+
+In `pushServiceImages` (`deploy.go` ~line 365-372), the call is currently `pushImageFunc(registryImage)`. Change it to pass whether this service targets a non-host platform:
+
+```go
+		logging.Info("Pushing image", "image", registryImage)
+		if err := pushImageFunc(registryImage, svc.Platform != ""); err != nil {
+			return fmt.Errorf("failed to push image for service %q: %w", name, err)
+		}
+```
+
+Rationale for `svc.Platform != ""`: in Phase 1 a non-empty `platform:` is exactly the "built for a specific (possibly non-host) arch" signal. Phase 2 refines this.
+
+In `cmd/banyan-cli/cmd/deploy_test.go`, find every mock `pushImageFunc = func(image string) error {` (search the file) and change the signature to:
+
+```go
+	pushImageFunc = func(image string, allPlatforms bool) error {
+```
+
+(Leave bodies unchanged.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run 'TestPushImageArgs|TestPushServiceImages' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Verify the module builds and full CLI test suite passes**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go build ./... && go test ./cmd/`
+Expected: build clean; PASS.
+
+---
+
+## Task 4: QEMU binfmt preflight check
+
+**Files:**
+- Create: `cmd/banyan-cli/cmd/preflight.go`
+- Create: `cmd/banyan-cli/cmd/preflight_test.go`
+
+The check reads `/proc/sys/fs/binfmt_misc/qemu-<arch>` where `<arch>` is the QEMU CPU name (`aarch64` for arm64, `x86_64` for amd64). It only matters when the requested platform's arch differs from the host arch.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/banyan-cli/cmd/preflight_test.go`:
+
+```go
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestQemuCPUName(t *testing.T) {
+	cases := map[string]string{
+		"linux/arm64": "aarch64",
+		"arm64":       "aarch64",
+		"linux/amd64": "x86_64",
+		"amd64":       "x86_64",
+	}
+	for platform, want := range cases {
+		if got := qemuCPUName(platform); got != want {
+			t.Errorf("qemuCPUName(%q) = %q, want %q", platform, got, want)
+		}
+	}
+}
+
+func TestBinfmtRegistered(t *testing.T) {
+	dir := t.TempDir()
+	// Simulate a registered, enabled handler.
+	if err := os.WriteFile(filepath.Join(dir, "qemu-aarch64"), []byte("enabled\ninterpreter /usr/bin/qemu-aarch64-static\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !binfmtRegistered(dir, "aarch64") {
+		t.Error("expected aarch64 to be registered")
+	}
+	if binfmtRegistered(dir, "x86_64") {
+		t.Error("expected x86_64 to be unregistered (no file)")
+	}
+}
+
+func TestBinfmtRegistered_DisabledHandler(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "qemu-aarch64"), []byte("disabled\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if binfmtRegistered(dir, "aarch64") {
+		t.Error("expected disabled handler to count as not registered")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run 'TestQemuCPUName|TestBinfmtRegistered' -v`
+Expected: FAIL — `undefined: qemuCPUName`, `undefined: binfmtRegistered`.
+
+- [ ] **Step 3: Implement `preflight.go`**
+
+Create `cmd/banyan-cli/cmd/preflight.go`:
+
+```go
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const binfmtDir = "/proc/sys/fs/binfmt_misc"
+
+// qemuCPUName maps a platform string (e.g. "linux/arm64" or "arm64") to the
+// QEMU user-static CPU name used in the binfmt_misc handler filename.
+func qemuCPUName(platform string) string {
+	arch := platform
+	if i := strings.LastIndex(platform, "/"); i >= 0 {
+		arch = platform[i+1:]
+	}
+	switch arch {
+	case "arm64", "aarch64":
+		return "aarch64"
+	case "amd64", "x86_64":
+		return "x86_64"
+	default:
+		return arch
+	}
+}
+
+// binfmtRegistered reports whether an enabled qemu-<cpu> handler exists under dir.
+func binfmtRegistered(dir, cpu string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "qemu-"+cpu))
+	if err != nil {
+		return false
+	}
+	// The handler file's first line is "enabled" or "disabled".
+	return strings.HasPrefix(strings.TrimSpace(string(data)), "enabled")
+}
+
+// hostCPU returns the QEMU CPU name for the machine running the CLI.
+func hostCPU() string {
+	return qemuCPUName(runtime.GOARCH)
+}
+
+// checkEmulation verifies that every non-host platform in platforms has a
+// registered QEMU binfmt handler. Returns an actionable error if not.
+func checkEmulation(platforms []string) error {
+	host := hostCPU()
+	var missing []string
+	seen := map[string]bool{}
+	for _, p := range platforms {
+		cpu := qemuCPUName(p)
+		if cpu == host || seen[cpu] {
+			continue
+		}
+		seen[cpu] = true
+		if !binfmtRegistered(binfmtDir, cpu) {
+			missing = append(missing, cpu)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"cross-arch build requires QEMU emulation for %s, but no binfmt handler is registered.\n"+
+			"Install it with either:\n"+
+			"  sudo bash install-deps.sh   # installs qemu-user-static + binfmt-support\n"+
+			"or:\n"+
+			"  sudo nerdctl run --privileged --rm tonistiigi/binfmt --install %s",
+		strings.Join(missing, ", "), strings.Join(missing, ","))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run 'TestQemuCPUName|TestBinfmtRegistered' -v`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Verify build**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go build ./...`
+Expected: clean.
+
+---
+
+## Task 5: Wire preflight + `--platform` flag into `runDeploy`
+
+**Files:**
+- Modify: `cmd/banyan-cli/cmd/deploy.go` — add `deployPlatform` var + flag (init, ~line 68-73); apply the flag to services and run preflight before building (in `runDeploy`, before the `buildServiceImages` call at line ~147)
+- Test: `cmd/banyan-cli/cmd/deploy_test.go` (append `TestCollectBuildPlatforms` + `TestApplyPlatformOverride`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/banyan-cli/cmd/deploy_test.go`:
+
+```go
+func TestApplyPlatformOverride(t *testing.T) {
+	services := map[string]types.ManifestService{
+		"web": {Build: &types.ManifestBuild{Context: "./web"}},
+		"api": {Build: &types.ManifestBuild{Context: "./api"}, Platform: "linux/amd64"},
+		"db":  {Image: "mysql:8.0"}, // no build — untouched
+	}
+	applyPlatformOverride(services, "linux/arm64")
+	if services["web"].Platform != "linux/arm64" {
+		t.Errorf("web: override should set empty platform, got %q", services["web"].Platform)
+	}
+	if services["api"].Platform != "linux/arm64" {
+		t.Errorf("api: global flag should win over per-service, got %q", services["api"].Platform)
+	}
+	if services["db"].Platform != "" {
+		t.Errorf("db: non-build service must be untouched, got %q", services["db"].Platform)
+	}
+}
+
+func TestCollectBuildPlatforms(t *testing.T) {
+	services := map[string]types.ManifestService{
+		"web": {Build: &types.ManifestBuild{Context: "./web"}, Platform: "linux/arm64"},
+		"api": {Build: &types.ManifestBuild{Context: "./api"}}, // no platform
+		"db":  {Image: "mysql:8.0", Platform: "linux/arm64"},   // no build — ignored
+	}
+	got := collectBuildPlatforms(services)
+	if len(got) != 1 || got[0] != "linux/arm64" {
+		t.Errorf("expected [linux/arm64], got %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run 'TestApplyPlatformOverride|TestCollectBuildPlatforms' -v`
+Expected: FAIL — `undefined: applyPlatformOverride`, `undefined: collectBuildPlatforms`.
+
+- [ ] **Step 3: Implement the two helpers**
+
+Add to `cmd/banyan-cli/cmd/deploy.go` (near `buildServiceImages`):
+
+```go
+// applyPlatformOverride sets Platform on every build service to the given value.
+// Used by the global --platform flag; wins over per-service platform:.
+func applyPlatformOverride(services map[string]types.ManifestService, platform string) {
+	if platform == "" {
+		return
+	}
+	for name, svc := range services { //nolint:gocritic // map iteration
+		if svc.Build == nil {
+			continue
+		}
+		svc.Platform = platform
+		services[name] = svc
+	}
+}
+
+// collectBuildPlatforms returns the distinct platform strings across all build
+// services (skipping empty ones). Used for the emulation preflight.
+func collectBuildPlatforms(services map[string]types.ManifestService) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, svc := range services { //nolint:gocritic // map iteration
+		if svc.Build == nil || svc.Platform == "" {
+			continue
+		}
+		if !seen[svc.Platform] {
+			seen[svc.Platform] = true
+			out = append(out, svc.Platform)
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Add the flag and wire both helpers into `runDeploy`**
+
+In `cmd/banyan-cli/cmd/deploy.go`, add the var next to the other deploy vars (top of file, the `var (...)` block around line 17-22):
+
+```go
+	deployPlatform string
+```
+
+In `init()` (line ~68), add:
+
+```go
+	deployCmd.Flags().StringVar(&deployPlatform, "platform", "", "Override build platform for all build services (e.g., linux/arm64)")
+```
+
+In `runDeploy`, immediately **before** the `buildServiceImages` call (currently line 147), insert:
+
+```go
+	// Apply the global --platform override, then verify QEMU emulation is
+	// available for any non-host build platform before we attempt a build.
+	applyPlatformOverride(manifest.Services, deployPlatform)
+	if emuErr := checkEmulation(collectBuildPlatforms(manifest.Services)); emuErr != nil {
+		return emuErr
+	}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run 'TestApplyPlatformOverride|TestCollectBuildPlatforms' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Full CLI module build + test**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go build ./... && go test ./cmd/`
+Expected: build clean; PASS.
+
+---
+
+## Task 6: Installer — `install_qemu_binfmt()`
+
+**Files:**
+- Modify: `install-deps.sh` — add `install_qemu_binfmt()` (near `install_buildkit`, ~line 329), call it in the agent/all branch of `install_deps()` (~line 586-592)
+
+Rationale: build boxes install the same builder deps as an agent (containerd + nerdctl + buildkit). QEMU binfmt belongs beside buildkit. This replaces the "install buildx" idea — the stack is BuildKit, not Docker, so `buildx` does not apply.
+
+- [ ] **Step 1: Add the function**
+
+In `install-deps.sh`, add after `install_buildkit()` (ends ~line 367):
+
+```bash
+install_qemu_binfmt() {
+    # Cross-arch image builds run foreign binaries under QEMU user emulation,
+    # registered via binfmt_misc. Needed on any box that cross-builds (e.g. an
+    # amd64 build host targeting arm64 agents).
+    if [ -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ] && [ -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]; then
+        info "QEMU binfmt handlers already registered, skipping."
+        return
+    fi
+
+    info "Installing QEMU user-static emulation (for cross-arch builds)..."
+
+    local family
+    family=$(get_family)
+    if [ "$family" = "debian" ]; then
+        $PKG_UPDATE
+        install_pkg "qemu-user-static"
+        install_pkg "binfmt-support"
+    else
+        install_pkg "qemu-user-static"
+    fi
+
+    # Register handlers for all arches with the buildkit/containerd worker.
+    # tonistiigi/binfmt is the most reliable cross-distro registrar.
+    if command -v nerdctl &>/dev/null; then
+        nerdctl run --privileged --rm tonistiigi/binfmt --install all >/dev/null 2>&1 || \
+            warn "tonistiigi/binfmt registration failed; qemu-user-static package handlers will be used."
+    fi
+
+    info "QEMU binfmt emulation installed."
+}
+```
+
+- [ ] **Step 2: Call it in the agent/all branch**
+
+In `install_deps()` (~line 586), add the call after `install_buildkit`:
+
+```bash
+    if [ "$ROLE" = "agent" ] || [ "$ROLE" = "all" ]; then
+        install_containerd
+        install_nerdctl
+        install_cni
+        install_wireguard
+        install_buildkit
+        install_qemu_binfmt  # For cross-arch image builds
+        install_nfs_client   # For NFS volume mounts
+    fi
+```
+
+- [ ] **Step 3: Verify the script parses**
+
+Run: `cd /home/work/freelancer/banyan && bash -n install-deps.sh`
+Expected: no output, exit 0 (syntax OK).
+
+- [ ] **Step 4: Confirm the function is discoverable when sourced**
+
+Run: `cd /home/work/freelancer/banyan && bash -c 'set -e; source install-deps.sh >/dev/null 2>&1 || true; declare -F install_qemu_binfmt'`
+Expected: prints `install_qemu_binfmt`.
+
+> **Note:** Actually installing QEMU requires `sudo` and a real environment — the user runs `sudo bash install-deps.sh` (or sources the function) in their own terminal. Do not run the install here.
+
+---
+
+## Task 7: Phase 1 docs
+
+**Files:**
+- Modify: `docs/` — find the manifest reference doc and document `platform:` + the QEMU requirement.
+
+- [ ] **Step 1: Locate the manifest reference doc**
+
+Run: `cd /home/work/freelancer/banyan && rg -l "placement|build:|banyan.yaml" docs/ | head`
+Expected: a list of docs; pick the manifest/reference one (e.g. a compose-compat or manifest doc). If none documents service fields, add a short section to `README.md` under the manifest description instead.
+
+- [ ] **Step 2: Add the documentation**
+
+Add this section to the chosen doc:
+
+```markdown
+### Building for a specific architecture (`platform:`)
+
+`banyan-cli` builds images on the machine running the CLI. If your agents run a
+different CPU architecture (e.g. arm64 Ampere servers while you build on an
+amd64 laptop), set `platform:` on each build service:
+
+```yaml
+services:
+  api:
+    build: ./api
+    platform: linux/arm64
+```
+
+Or override all build services at once:
+
+```bash
+sudo banyan-cli up --platform linux/arm64
+```
+
+Cross-arch builds run under QEMU emulation, which must be installed on the build
+box (`install-deps.sh` installs it, or run
+`sudo nerdctl run --privileged --rm tonistiigi/binfmt --install all`). If it is
+missing, `banyan-cli up` fails fast with install instructions.
+```
+
+- [ ] **Step 3: Verify no broken markdown / dead file**
+
+Run: `cd /home/work/freelancer/banyan && rg -n "platform: linux/arm64" docs/ README.md`
+Expected: the new lines appear. (No commit.)
+
+---
+
+# PHASE 2 — Auto-detect arch from the cluster
+
+## Task 8: Add `arch` to the proto and regenerate
+
+**Files:**
+- Modify: `pkg/rpc/proto/banyan/v1/engine.proto:81-88` (`RegisterRequest`), `:323-330` (`AgentInfo`)
+- Regenerate: `pkg/rpc/banyanpb/*.pb.go` via `make proto`
+
+- [ ] **Step 1: Edit the proto**
+
+In `RegisterRequest` (line 81), add field 7:
+
+```proto
+message RegisterRequest {
+  string agent_name = 1;
+  string api_address = 2;
+  string session_token = 3;
+  repeated string tags = 4;
+  string wg_public_key = 5;       // agent's WireGuard public key
+  string host_ip = 6;             // agent's data-plane host IP (for overlay peer endpoint)
+  string arch = 7;                // agent's CPU arch (runtime.GOARCH: "amd64" | "arm64")
+}
+```
+
+In `AgentInfo` (line 323), add field 7:
+
+```proto
+message AgentInfo {
+  string name = 1;
+  string status = 2;
+  string api_address = 3;
+  int64 last_seen_unix = 4;
+  int64 created_at_unix = 5;
+  repeated string tags = 6;
+  string arch = 7;                // agent's CPU arch, empty if agent predates arch reporting
+}
+```
+
+- [ ] **Step 2: Regenerate the Go bindings**
+
+Run: `cd /home/work/freelancer/banyan && make proto`
+Expected: exit 0; `git status --short pkg/rpc/banyanpb/` shows modified `engine.pb.go` (do NOT commit).
+
+If `protoc` or its plugins are missing, install per `README`/`DEVELOPMENT.md` first. Verify the field exists:
+
+Run: `cd /home/work/freelancer/banyan && rg -n "Arch " pkg/rpc/banyanpb/engine.pb.go | head`
+Expected: generated `Arch string` getters on `RegisterRequest` and `AgentInfo`.
+
+- [ ] **Step 3: Verify everything still builds after regen**
+
+Run: `cd /home/work/freelancer/banyan && go build ./...`
+Expected: clean (no consumers broke — new fields are additive).
+
+---
+
+## Task 9: Agent reports `runtime.GOARCH` at registration
+
+**Files:**
+- Modify: `pkg/agent/engine_client.go:101-116` (`RegisterRequest` struct + the proto call)
+- Test: `pkg/agent/engine_client_test.go` (append a test asserting the arch is sent)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/agent/engine_client_test.go`:
+
+```go
+func TestRegister_SendsArch(t *testing.T) {
+	var gotArch string
+	srv := &testEngineServer{
+		registerFunc: func(ctx context.Context, req *banyanpb.RegisterRequest) (*banyanpb.RegisterResponse, error) {
+			gotArch = req.Arch
+			return &banyanpb.RegisterResponse{RegistryUrl: "reg:5000"}, nil
+		},
+	}
+	client, cleanup := newTestEngineClient(t, srv)
+	defer cleanup()
+
+	_, _, _, err := client.Register(context.Background(), RegisterRequest{Name: "worker-1", APIAddr: "addr"})
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	if gotArch != runtime.GOARCH {
+		t.Errorf("expected arch %q, got %q", runtime.GOARCH, gotArch)
+	}
+}
+```
+
+> Before writing, confirm the helper names: run `rg -n "func newTestEngineClient|registerFunc" pkg/agent/engine_client_test.go`. The file already defines a `testEngineServer` with a `registerFunc` field (used at line ~70) and a client constructor helper — reuse the exact names it uses. If the constructor helper has a different name, substitute it. Add `"runtime"` to the test file's imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/work/freelancer/banyan && go test ./pkg/agent/ -run TestRegister_SendsArch -v`
+Expected: FAIL — `gotArch` is `""`, not `runtime.GOARCH` (or a compile error on `req.Arch` if Task 8 was skipped — Task 8 must be done first).
+
+- [ ] **Step 3: Send the arch**
+
+In `pkg/agent/engine_client.go`, add `"runtime"` to imports, then set `Arch` in the proto call (line 110):
+
+```go
+	resp, err := ec.client.Register(ctx, &banyanpb.RegisterRequest{
+		AgentName:   req.Name,
+		ApiAddress:  req.APIAddr,
+		Tags:        req.Tags,
+		WgPublicKey: req.WGPublicKey,
+		HostIp:      req.HostIP,
+		Arch:        runtime.GOARCH,
+	})
+```
+
+(The `RegisterRequest` Go struct at line 101 does not need an `Arch` field — the arch is sourced from `runtime.GOARCH` at call time, not passed by callers. This keeps every existing caller unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/work/freelancer/banyan && go test ./pkg/agent/ -run TestRegister_SendsArch -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the agent package builds + tests pass**
+
+Run: `cd /home/work/freelancer/banyan && go build ./pkg/agent/ && go test ./pkg/agent/`
+Expected: clean; PASS.
+
+---
+
+## Task 10: Persist arch on the engine's `NodeRecord`
+
+**Files:**
+- Modify: `pkg/types/records.go:134-145` (`NodeRecord`)
+- Modify: `pkg/engine/grpc_handlers_agent.go:41-48` (Register handler node creation)
+- Test: `pkg/engine/grpc_handlers_agent_test.go` (append; verify stored arch)
+
+- [ ] **Step 1: Add the field to `NodeRecord`**
+
+In `pkg/types/records.go`, add to `NodeRecord`:
+
+```go
+type NodeRecord struct {
+	LastSeen         time.Time `json:"last_seen"`
+	CreatedAt        time.Time `json:"created_at"`
+	Name             string    `json:"name"`
+	Status           string    `json:"status"`
+	APIAddress       string    `json:"api_address,omitempty"`
+	Arch             string    `json:"arch,omitempty"`
+	Tags             []string  `json:"tags,omitempty"`
+	MemoryTotalBytes uint64    `json:"memory_total_bytes,omitempty"`
+	MemoryUsedBytes  uint64    `json:"memory_used_bytes,omitempty"`
+	CPUCores         uint32    `json:"cpu_cores,omitempty"`
+	CPUUsageRatio    float64   `json:"cpu_usage_ratio,omitempty"`
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+First inspect an existing Register handler test to reuse its harness: `rg -n "func Test.*Register" pkg/engine/grpc_handlers_agent_test.go`. Mirror its setup (store, server construction). Append a test that registers with `Arch: "arm64"` and asserts the saved `NodeRecord.Arch`:
+
+```go
+func TestRegister_PersistsArch(t *testing.T) {
+	s, store := newTestEngineServer(t) // reuse whatever the file's existing helper is named
+	ctx := context.Background()
+
+	_, err := s.Register(ctx, &banyanpb.RegisterRequest{
+		AgentName:  "worker-1",
+		ApiAddress: "10.0.0.5:9100",
+		Arch:       "arm64",
+	})
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	var node types.NodeRecord
+	if err := store.Get(ctx, types.KeyNodes+"worker-1", &node); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if node.Arch != "arm64" {
+		t.Errorf("expected arch arm64, got %q", node.Arch)
+	}
+}
+```
+
+> If the file's helper has a different name/signature than `newTestEngineServer`, adapt to match (check with the `rg` above). The VPC allocator may be nil in the harness — that path is guarded by `if s.allocator != nil`, so registration still succeeds.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /home/work/freelancer/banyan && go test ./pkg/engine/ -run TestRegister_PersistsArch -v`
+Expected: FAIL — `node.Arch` is `""`.
+
+- [ ] **Step 4: Store the arch in the handler**
+
+In `pkg/engine/grpc_handlers_agent.go`, add `Arch` to the node record (line ~42):
+
+```go
+	node := &types.NodeRecord{
+		Name:       req.AgentName,
+		Status:     "ready",
+		APIAddress: req.ApiAddress,
+		Arch:       req.Arch,
+		Tags:       req.Tags,
+		LastSeen:   time.Now(),
+		CreatedAt:  time.Now(),
+	}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /home/work/freelancer/banyan && go test ./pkg/engine/ -run TestRegister_PersistsArch -v`
+Expected: PASS.
+
+- [ ] **Step 6: Verify engine + types build and tests pass**
+
+Run: `cd /home/work/freelancer/banyan && go build ./pkg/engine/ ./pkg/types/ && go test ./pkg/engine/ ./pkg/types/`
+Expected: clean; PASS.
+
+---
+
+## Task 11: Expose arch via `GetStatus` (AgentInfo)
+
+**Files:**
+- Modify: `pkg/engine/grpc_handlers_cli.go:225-233` (the `AgentInfo` construction inside `GetStatus`)
+- Test: `pkg/engine/grpc_handlers_cli_test.go` (append or extend an existing GetStatus test)
+
+> Note: `GetInfo` (line 357) only returns the registry URL and does not list agents. The agent list the CLI consumes comes from `GetStatus` → `GetStatusResponse.Agents`. So we surface arch there.
+
+- [ ] **Step 1: Write the failing test**
+
+Inspect existing GetStatus tests: `rg -n "func Test.*GetStatus" pkg/engine/grpc_handlers_cli_test.go`. Reuse the harness. Append:
+
+```go
+func TestGetStatus_ReturnsAgentArch(t *testing.T) {
+	s, store := newTestEngineServer(t) // match the file's helper name
+	ctx := context.Background()
+
+	node := &types.NodeRecord{Name: "worker-1", Status: "ready", Arch: "arm64"}
+	if err := store.Save(ctx, types.KeyNodes+"worker-1", node); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := s.GetStatus(ctx, &banyanpb.GetStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	var found *banyanpb.AgentInfo
+	for _, a := range resp.Agents {
+		if a.Name == "worker-1" {
+			found = a
+		}
+	}
+	if found == nil {
+		t.Fatal("worker-1 not in agents")
+	}
+	if found.Arch != "arm64" {
+		t.Errorf("expected arch arm64, got %q", found.Arch)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/work/freelancer/banyan && go test ./pkg/engine/ -run TestGetStatus_ReturnsAgentArch -v`
+Expected: FAIL — `found.Arch` is `""`.
+
+- [ ] **Step 3: Populate `Arch` in the AgentInfo**
+
+In `pkg/engine/grpc_handlers_cli.go` (line ~226), add `Arch`:
+
+```go
+		agents = append(agents, &banyanpb.AgentInfo{
+			Name:          node.Name,
+			Status:        node.Status,
+			ApiAddress:    node.APIAddress,
+			LastSeenUnix:  node.LastSeen.Unix(),
+			CreatedAtUnix: node.CreatedAt.Unix(),
+			Tags:          node.Tags,
+			Arch:          node.Arch,
+		})
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/work/freelancer/banyan && go test ./pkg/engine/ -run TestGetStatus_ReturnsAgentArch -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify engine build + tests**
+
+Run: `cd /home/work/freelancer/banyan && go build ./pkg/engine/ && go test ./pkg/engine/`
+Expected: clean; PASS.
+
+---
+
+## Task 12: Per-service platform resolution logic
+
+**Files:**
+- Create: `cmd/banyan-cli/cmd/platform.go`
+- Create: `cmd/banyan-cli/cmd/platform_test.go`
+
+This is the pure decision core (the 5 precedence rules from the spec), separated from any gRPC/IO so it is fully table-testable.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/banyan-cli/cmd/platform_test.go`:
+
+```go
+package cmd
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/fertile-org/banyan/pkg/types"
+)
+
+func TestResolveServicePlatform(t *testing.T) {
+	archOf := map[string]string{
+		"node-amd": "amd64",
+		"node-arm": "arm64",
+	}
+	all := []string{"amd64", "arm64"}
+
+	tests := []struct {
+		name string
+		svc  types.ManifestService
+		want string
+	}{
+		{
+			name: "explicit platform wins",
+			svc:  types.ManifestService{Build: &types.ManifestBuild{Context: "."}, Platform: "linux/riscv64"},
+			want: "linux/riscv64",
+		},
+		{
+			name: "placement node arch",
+			svc:  types.ManifestService{Build: &types.ManifestBuild{Context: "."}, Deploy: &types.ManifestDeploy{Placement: &types.ManifestPlacement{Node: "node-arm"}}},
+			want: "linux/arm64",
+		},
+		{
+			name: "no constraint -> union of all cluster arches",
+			svc:  types.ManifestService{Build: &types.ManifestBuild{Context: "."}},
+			want: "linux/amd64,linux/arm64",
+		},
+		{
+			name: "placement to unknown node -> host fallback (empty)",
+			svc:  types.ManifestService{Build: &types.ManifestBuild{Context: "."}, Deploy: &types.ManifestDeploy{Placement: &types.ManifestPlacement{Node: "ghost"}}},
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveServicePlatform(tc.svc, archOf, all)
+			if normalizePlatforms(got) != normalizePlatforms(tc.want) {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// normalizePlatforms sorts a comma-list so order does not matter in assertions.
+func normalizePlatforms(p string) string {
+	if p == "" {
+		return ""
+	}
+	parts := strings.Split(p, ",")
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func TestClusterArches(t *testing.T) {
+	agents := []*fakeAgent{{name: "a", arch: "amd64"}, {name: "b", arch: "arm64"}, {name: "c", arch: ""}}
+	archOf, all := clusterArches(toAgentInfo(agents))
+	if archOf["a"] != "amd64" || archOf["b"] != "arm64" {
+		t.Errorf("archOf wrong: %v", archOf)
+	}
+	if _, ok := archOf["c"]; ok {
+		t.Error("empty-arch agent should be omitted from archOf")
+	}
+	if normalizePlatforms(strings.Join(all, ",")) != "amd64,arm64" {
+		t.Errorf("all arches wrong: %v", all)
+	}
+}
+```
+
+> The `fakeAgent`/`toAgentInfo` helpers below convert to `*banyanpb.AgentInfo`. Add them to `platform_test.go`:
+
+```go
+type fakeAgent struct{ name, arch string }
+
+func toAgentInfo(fs []*fakeAgent) []*banyanpb.AgentInfo {
+	var out []*banyanpb.AgentInfo
+	for _, f := range fs {
+		out = append(out, &banyanpb.AgentInfo{Name: f.name, Arch: f.arch})
+	}
+	return out
+}
+```
+
+Add `"github.com/fertile-org/banyan/pkg/rpc/banyanpb"` to the test imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run 'TestResolveServicePlatform|TestClusterArches' -v`
+Expected: FAIL — `undefined: resolveServicePlatform`, `undefined: clusterArches`.
+
+- [ ] **Step 3: Implement `platform.go`**
+
+Create `cmd/banyan-cli/cmd/platform.go`:
+
+```go
+package cmd
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/fertile-org/banyan/pkg/rpc/banyanpb"
+	"github.com/fertile-org/banyan/pkg/types"
+)
+
+// clusterArches builds a name→arch map (omitting agents that report no arch)
+// and the sorted set of distinct arches present in the cluster.
+func clusterArches(agents []*banyanpb.AgentInfo) (map[string]string, []string) {
+	archOf := map[string]string{}
+	set := map[string]bool{}
+	for _, a := range agents {
+		if a.Arch == "" {
+			continue
+		}
+		archOf[a.Name] = a.Arch
+		set[a.Arch] = true
+	}
+	var all []string
+	for arch := range set {
+		all = append(all, arch)
+	}
+	sort.Strings(all)
+	return archOf, all
+}
+
+// resolveServicePlatform returns the nerdctl --platform value for one build
+// service, applying the precedence rules. Returns "" to mean "build host arch"
+// (the caller's fallback), which also covers the unknown/offline cases.
+func resolveServicePlatform(svc types.ManifestService, archOf map[string]string, allArches []string) string {
+	// Rule 1: explicit platform wins.
+	if svc.Platform != "" {
+		return svc.Platform
+	}
+	// Rule 2: pinned to a node — use that node's arch (if known).
+	if svc.Deploy != nil && svc.Deploy.Placement != nil && svc.Deploy.Placement.Node != "" {
+		if arch, ok := archOf[svc.Deploy.Placement.Node]; ok {
+			return "linux/" + arch
+		}
+		return "" // unknown node arch → host fallback
+	}
+	// Rule 4: no placement constraint — union of all cluster arches.
+	// (Rule 3, tag-based union, is folded into "all" for now: without a tag
+	// filter we target every known arch, which is always safe.)
+	if len(allArches) == 0 {
+		return "" // no arch info at all → host fallback
+	}
+	var platforms []string
+	for _, a := range allArches {
+		platforms = append(platforms, "linux/"+a)
+	}
+	return strings.Join(platforms, ",")
+}
+```
+
+> **Scope note (Rule 3):** tag-based arch narrowing is intentionally folded into the "all cluster arches" union — targeting a superset of arches is always safe (the extra layers are just unused). A precise tag→agent→arch intersection is a future refinement, not needed for correctness. This is called out in the spec's testing section.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/ -run 'TestResolveServicePlatform|TestClusterArches' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify module builds**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go build ./...`
+Expected: clean.
+
+---
+
+## Task 13: Wire auto-detection into `runDeploy`
+
+**Files:**
+- Modify: `cmd/banyan-cli/cmd/deploy.go` — reorder so the engine/agent list is fetched before building; apply `resolveServicePlatform` to each build service; keep host-arch fallback + warning
+- Test: manual (integration) — documented; no new unit test (covered by Task 12 core)
+
+The reorder: today `buildServiceImages` runs at line 147, before the engine client exists. We move the "connect + get status + resolve platforms" ahead of the build, while keeping `--dry-run` and engine-offline working via fallback.
+
+- [ ] **Step 1: Add a platform-resolution helper that warns on fallback**
+
+Add to `cmd/banyan-cli/cmd/platform.go`:
+
+```go
+import "github.com/fertile-org/banyan/pkg/logging"
+
+// applyResolvedPlatforms fills Platform on every build service that does not
+// already have one, using cluster arch info. Services left empty fall back to
+// the build host arch; we warn so the operator knows why.
+func applyResolvedPlatforms(services map[string]types.ManifestService, agents []*banyanpb.AgentInfo) {
+	archOf, all := clusterArches(agents)
+	for name, svc := range services { //nolint:gocritic // map iteration
+		if svc.Build == nil || svc.Platform != "" {
+			continue
+		}
+		resolved := resolveServicePlatform(svc, archOf, all)
+		if resolved == "" {
+			logging.Warn("Could not determine target arch; building for host arch",
+				"service", name,
+				"hint", "upgrade agents to report arch, or set platform: on the service")
+			continue
+		}
+		svc.Platform = resolved
+		services[name] = svc
+	}
+}
+```
+
+> Move the `logging` import into the existing import block of `platform.go` (do not create a second `import` statement).
+
+- [ ] **Step 2: Reorder `runDeploy`**
+
+In `cmd/banyan-cli/cmd/deploy.go`, restructure `runDeploy` so the flow is: parse → validate → (dry-run branch unchanged, still builds host-arch) → connect engine → `Status()` → `applyResolvedPlatforms` → `applyPlatformOverride` (flag still wins) → `checkEmulation` → `buildServiceImages` → push → deploy.
+
+Concretely: **remove** the early build block at line ~146-149:
+
+```go
+	// Build images for services with build config
+	manifestDir := filepath.Dir(deployFile)
+	if buildErr := buildServiceImages(manifestDir, manifest.Name, manifest.Services); buildErr != nil {
+		return buildErr
+	}
+```
+
+Keep `manifestDir := filepath.Dir(deployFile)` (it is used later for env/volume resolution) — leave that assignment, just remove the build call. Then in the **dry-run branch** (line ~159), build host-arch first so `--dry-run` still validates the build locally offline:
+
+```go
+	if deployDryRun {
+		// Offline: build for host arch (no engine to ask). --platform still honored.
+		applyPlatformOverride(manifest.Services, deployPlatform)
+		if emuErr := checkEmulation(collectBuildPlatforms(manifest.Services)); emuErr != nil {
+			return emuErr
+		}
+		if buildErr := buildServiceImages(manifestDir, manifest.Name, manifest.Services); buildErr != nil {
+			return buildErr
+		}
+		services := types.BuildServiceRecords(manifest.Services)
+		fmt.Printf("Application: %s\n", manifest.Name)
+		fmt.Printf("Services: %d\n", len(manifest.Services))
+		for name, svc := range services { //nolint:gocritic // display-only loop
+			fmt.Printf("  - %s: %s (replicas: %d)\n", name, svc.Image, svc.Replicas)
+		}
+		fmt.Println("\n[DRY-RUN] Manifest is valid. No changes made.")
+		return nil
+	}
+```
+
+After the engine client + `info` are obtained (the block around line 180-191), and **before** `pushServiceImages`, insert the resolve+build sequence:
+
+```go
+	// Resolve each build service's target platform from the cluster's agents,
+	// then build. --platform flag overrides everything; missing arch info falls
+	// back to host arch (with a warning) so offline-ish clusters still work.
+	status, statusErr := client.Status(ctx)
+	if statusErr != nil {
+		logging.Warn("Could not list agents; building for host arch", "err", statusErr)
+	} else {
+		applyResolvedPlatforms(manifest.Services, status.Agents)
+	}
+	applyPlatformOverride(manifest.Services, deployPlatform)
+	if emuErr := checkEmulation(collectBuildPlatforms(manifest.Services)); emuErr != nil {
+		return emuErr
+	}
+	if buildErr := buildServiceImages(manifestDir, manifest.Name, manifest.Services); buildErr != nil {
+		return buildErr
+	}
+
+	// Push built images to registry
+	if pushErr := pushServiceImages(info.RegistryUrl, manifest.Services); pushErr != nil {
+		return pushErr
+	}
+```
+
+> Ensure `pushServiceImages` still runs after the build (it already followed the old push site). The push at line ~192 that already exists should be the one shown above — do not double-call it.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go build ./...`
+Expected: clean. If `status` shadows an import or unused-var errors appear, rename the local to `st`.
+
+- [ ] **Step 4: Run the full CLI test suite**
+
+Run: `cd /home/work/freelancer/banyan/cmd/banyan-cli && go test ./cmd/`
+Expected: PASS (existing deploy tests still green; the reorder does not change dry-run's public behavior beyond building host-arch, which the mocks tolerate).
+
+- [ ] **Step 5: Full-workspace build + vet**
+
+Run: `cd /home/work/freelancer/banyan && go build ./... && go vet ./...`
+Expected: clean.
+
+---
+
+## Task 14: End-to-end verification (manual, user-run)
+
+**Files:** none (operational verification on the real takahiro-dev cluster)
+
+> This task is run by the user in their own terminal (server access is theirs, not the agent's). The plan lists the commands; the agent guides and interprets output.
+
+- [ ] **Step 1: Rebuild + install the CLI from source**
+
+```bash
+cd /home/work/freelancer/banyan
+make build   # or: go build ./cmd/banyan-cli
+sudo install -m 0755 ./bin/banyan-cli /usr/local/bin/banyan-cli   # adjust path to the built binary
+```
+
+- [ ] **Step 2: Switch takahiro-dev manifest back to `build:`**
+
+Edit `deploy/takahiro-dev/banyan.yaml`: for the four app services (`caddy`, `admin`, `survey`, `backend`) replace the pinned `image: 10.200.185.161:5000/taka-dev-*:latest` lines with their original `build:` blocks (context dirs per `build-arm64.sh`), and add `platform: linux/arm64` under each. Leave `mysql` on `image: mysql:8.0`.
+
+- [ ] **Step 3: Deploy (CLI now cross-builds arm64 automatically)**
+
+```bash
+sudo banyan-cli up -f deploy/takahiro-dev/banyan.yaml
+```
+
+Expected: preflight passes (QEMU present); each build service builds `--platform=linux/arm64`; push uses `--all-platforms`; deployment proceeds. `mysql` reaches `healthy`; `caddy`/`admin`/`survey` `running`; `backend` may stay `restarting` until the DB dump is seeded (separate operational step, out of scope here).
+
+- [ ] **Step 4: Confirm agent arch is now reported**
+
+```bash
+sudo banyan-cli agent list   # or the status command; confirm arch column shows arm64
+```
+
+Expected: `banyan-agent-1` shows `arm64`. (This requires the engine + agent binaries to be rebuilt from this branch and restarted — a user-run server step.)
+
+- [ ] **Step 5: Verify running containers are arm64-native (no restart loop)**
+
+Expected: `caddy`/`admin`/`survey` stay `running` (not `restarting`), confirming the pulled layers match the agent arch.
+
+---
+
+## Self-Review notes (for the executor)
+
+- **Task ordering matters:** Task 8 (proto regen) must precede Tasks 9–11 (they reference `req.Arch` / `AgentInfo.Arch`). Phase 1 (Tasks 1–7) is independent of Phase 2 and already unblocks takahiro-dev on its own.
+- **No commits anywhere** — every "verify" step replaces the usual commit. If using subagent-driven execution, instruct each subagent explicitly not to commit.
+- **Helper names in engine/agent tests** (`newTestEngineServer`, `newTestEngineClient`, `testEngineServer.registerFunc`) are reused from existing test files; confirm exact names with the `rg` commands noted in each task before writing, and adapt if they differ.
+- **Spec coverage:** platform field (T1), --platform flag (T5), preflight (T4), installer QEMU (T6), docs (T7), proto arch (T8), agent reports (T9), engine stores (T10), status exposes (T11), resolution rules (T12), auto-detect wiring + host fallback/degrade (T13), E2E gap acknowledged as manual (T14). MySQL migration and remote-builder remain out of scope per spec.

--- a/docs/superpowers/specs/2026-07-07-install-sudo-secure-path-symlink-design.md
+++ b/docs/superpowers/specs/2026-07-07-install-sudo-secure-path-symlink-design.md
@@ -1,0 +1,122 @@
+# Installer: expose banyan binaries on sudo's secure_path — Design Spec
+
+**Date:** 2026-07-07
+**Status:** Approved (pending spec review)
+
+## Problem
+
+The install scripts place the banyan binaries in `/usr/local/bin` (`INSTALL_DIR` default). On Oracle Linux / RHEL / Fedora / CentOS, `sudo` runs with `env_reset` and resets `PATH` to a fixed `secure_path` declared in `/etc/sudoers`. That default `secure_path` (`/sbin:/bin:/usr/sbin:/usr/bin`) **does not include `/usr/local/bin`**.
+
+As a result, after a successful install, typing `sudo banyan-engine init` fails with `command not found` — even though the binary is installed and executable at `/usr/local/bin/banyan-engine`. The problem is purely that the command name does not resolve under `sudo` because `/usr/local/bin` is absent from `secure_path`. Debian/Ubuntu include `/usr/local/bin` in their default `secure_path`, so they are unaffected; RHEL-family and some others are affected.
+
+Observed on staging (2026-07-07, Oracle Linux 9.7 / arm64 / OCI): install log reported `banyan-engine ... installed to /usr/local/bin/banyan-engine` and `verify` passed, yet `sudo banyan-engine init` → `sudo: banyan-engine: command not found`.
+
+### Secondary issue (code smell)
+
+`install.sh` and `install-from-source.sh` both reference `$INSTALL_DIR` (e.g. `mv "$tmp" "${INSTALL_DIR}/${name}"`) but neither script defines it. The value only exists because they source `install-deps.sh`, which sets `INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"` at line 7. This is an implicit coupling: reading `install.sh` alone, the variable appears undefined. It is not a live bug today (`install.sh` uses `set -euo pipefail`, so an unset `INSTALL_DIR` would abort loudly rather than misbehave, and the source happens before first use), but it is fragile against reordering/refactoring.
+
+## Goal
+
+After install, `sudo banyan-engine`, `sudo banyan-agent`, and `sudo banyan-cli` work out of the box on every supported OS, without the operator having to edit sudo config or use full paths. Keep the real binaries at `/usr/local/bin` (FHS-correct home for locally installed software) and make the `INSTALL_DIR`/`LINK_DIR` configuration explicit in each entry script.
+
+## Chosen approach
+
+Expose the three banyan commands on `secure_path` by **symlinking** them from `INSTALL_DIR` into a directory that is on the default `secure_path` of every supported OS (`/usr/sbin`). This has the smallest blast radius: it exposes only the three banyan names, without widening `secure_path` for all sudo commands (which is what RHEL deliberately avoids) and without moving the binaries out of `/usr/local/bin`.
+
+### Approaches considered (and rejected)
+
+- **sudoers.d drop-in adding `/usr/local/bin` to `secure_path`.** Rejected: changes `secure_path` for *all* sudo invocations on the host — the exact hardening RHEL disables by default — so an installer doing it silently weakens system policy. Also requires `visudo -c` validation and 0440 perms.
+- **Install binaries directly into `/usr/bin`.** Rejected: `/usr/bin` is conventionally package-manager territory; a `curl | bash` installer writing there is less clean than keeping `/usr/local/bin` as the real home.
+
+## Design
+
+### 1. Shared config + helper in `install-deps.sh`
+
+`install-deps.sh` is sourced by both installers, so the symlink logic lives here once (DRY).
+
+Alongside `INSTALL_DIR` (line 7), add:
+
+```bash
+LINK_DIR="${LINK_DIR:-/usr/sbin}"
+```
+
+Add a helper:
+
+```bash
+# link_secure_path exposes an installed binary on sudo's secure_path by
+# symlinking it from INSTALL_DIR into LINK_DIR (default /usr/sbin). On RHEL/
+# Oracle/Fedora, sudo's secure_path excludes /usr/local/bin, so `sudo banyan-*`
+# fails with command-not-found even though the binary is installed. /usr/sbin
+# and /usr/bin are on the default secure_path of every supported OS.
+#
+# It never clobbers a real file: if LINK_DIR/<name> already exists as a regular
+# file (e.g. placed by a distro package or the user), it is left untouched and a
+# warning is emitted. An existing symlink (ours) is refreshed idempotently.
+link_secure_path() {
+    local name=$1
+    [ "$LINK_DIR" = "$INSTALL_DIR" ] && return 0   # avoid self-referential link
+    [ -d "$LINK_DIR" ] || return 0                 # skip if target dir absent
+    local target="${LINK_DIR}/${name}"
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+        warn "${target} is a real file — skipping symlink; use ${INSTALL_DIR}/${name} or the full path"
+        return 0
+    fi
+    ln -sf "${INSTALL_DIR}/${name}" "$target"
+}
+```
+
+The `-e && ! -L` guard means: only skip when a **real (non-symlink) file** already occupies the target. In the actual bug scenario `LINK_DIR/<name>` does not exist at all (the installer only ever wrote `/usr/local/bin`), so the guard does not trigger and the symlink is created — the fix applies. The guard only affects the rare case of a pre-existing real file, which it declines to destroy.
+
+### 2. Call the helper after each banyan binary is installed
+
+- `install.sh` → at the end of `install_binary()` (after the `mv` + info at lines 108/110): `link_secure_path "$name"`, then an info line noting the symlink.
+- `install-from-source.sh` → at the end of its build-install function (after the `mv` + info at lines 65/67): `link_secure_path "$name"`.
+
+Only the three banyan binaries (`banyan-cli`, `banyan-engine`, `banyan-agent`) are symlinked — exactly the commands an operator types. Dependencies installed into `INSTALL_DIR` by `install-deps.sh` (etcd, registry, nerdctl, buildkit) are not symlinked: they are invoked by the services via absolute paths, not typed by the operator (YAGNI).
+
+### 3. Make `INSTALL_DIR` / `LINK_DIR` explicit in the entry scripts
+
+Immediately after sourcing `install-deps.sh`, in **both** `install.sh` and `install-from-source.sh`:
+
+```bash
+# INSTALL_DIR / LINK_DIR are provided by install-deps.sh; re-assert defaults
+# here so this script is correct on its own even if sourcing is reordered.
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+LINK_DIR="${LINK_DIR:-/usr/sbin}"
+```
+
+Because of `:-`, defining them twice is harmless: `install-deps.sh` set them first, and these lines keep those values. Reading either entry script alone now shows both variables defined.
+
+## Non-Goals (YAGNI)
+
+- **No uninstall / symlink removal.** No uninstall script exists in the repo today. When one is added later, it must also `rm` the `LINK_DIR` symlinks (see Risks: dangling symlinks). Out of scope here.
+- **No symlinking of dependency binaries** (etcd, registry, nerdctl, buildkit).
+- **No change to `secure_path` or any sudo configuration.**
+- **No change to systemd units.** `ExecStart` already uses the absolute `${INSTALL_DIR}/banyan-*` path, so services are unaffected by this change.
+
+## Risks & notes
+
+- **Dangling symlink (most realistic future footgun).** Because there is no uninstaller, if the real binary in `/usr/local/bin` is removed while the `/usr/sbin` symlink remains, `sudo banyan-*` fails with `No such file or directory`. Mitigation deferred to a future uninstall script; low likelihood since the binary only disappears if the user deletes it.
+- **Real file at `LINK_DIR/<name>`.** Handled by the `-e && ! -L` guard: never clobbered, warning emitted, operator falls back to the full path. Practically never happens for the banyan names (not distro-packaged).
+- **usrmerge systems** where `/usr/sbin` is a symlink to `/usr/bin`: `ln -sf` resolves fine and the result is still on `secure_path`.
+- **Non-root LINK_DIR write:** installers already enforce root, so `/usr/sbin` is writable.
+
+## Testing
+
+- **Unit (isolated), for `link_secure_path`** — source `install-deps.sh`, point `INSTALL_DIR`/`LINK_DIR` at temp dirs, `touch` a fake binary, then assert:
+  - symlink is created and resolves to `INSTALL_DIR/<name>`;
+  - idempotent — calling twice leaves a correct symlink, no error;
+  - self-link guard — `LINK_DIR == INSTALL_DIR` creates nothing;
+  - missing-dir guard — absent `LINK_DIR` is a no-op, no error;
+  - real-file guard — a pre-existing regular file at the target is left intact and no symlink replaces it (warning path).
+- **Lint:** `shellcheck` on all three scripts — no new warnings.
+- **Manual on Oracle Linux 9:** after install, `sudo banyan-cli --help` runs without any sudoers change; `ls -la /usr/sbin/banyan-*` shows symlinks into `/usr/local/bin`.
+
+## Affected files
+
+| File | Change |
+|------|--------|
+| `install-deps.sh` | Add `LINK_DIR` default; add `link_secure_path()` helper |
+| `install.sh` | Re-assert `INSTALL_DIR`/`LINK_DIR` defaults; call `link_secure_path "$name"` in `install_binary()` |
+| `install-from-source.sh` | Re-assert `INSTALL_DIR`/`LINK_DIR` defaults; call `link_secure_path "$name"` after build-install |
+| (test) | Add isolated test for `link_secure_path` |

--- a/docs/superpowers/specs/2026-07-24-banyan-cli-multiarch-build-design.md
+++ b/docs/superpowers/specs/2026-07-24-banyan-cli-multiarch-build-design.md
@@ -1,0 +1,160 @@
+# banyan-cli multi-arch build — design
+
+**Date:** 2026-07-24
+**Status:** Approved design, pending spec review
+**Author:** Pham Dang Huy (with Claude)
+
+## Problem
+
+`banyan-cli up` builds container images on the machine that runs the CLI and
+pushes them to the engine registry ("Option B" build flow). The build path is
+architecture-blind: `buildImage` (`cmd/banyan-cli/cmd/deploy.go:314`) runs
+`nerdctl build -t <img> <ctx>` with no `--platform`, so images always inherit
+the build host's architecture.
+
+This breaks real deployments: the build box is an amd64 WSL2 machine, but the
+production agent `banyan-agent-1` (Oracle Cloud Ampere) is **aarch64/arm64**.
+amd64 images land on the arm64 agent and silently stay in `restarting`. The
+cluster has no way to know an agent's architecture — none of `RegisterRequest`
+(`engine.proto:81`), `HeartbeatRequest` (:110), `SystemMetrics` (:70), or
+`AgentInfo` (:323) carries an arch field.
+
+The current workaround for the takahiro-dev deploy is a hand-run
+`deploy/takahiro-dev/build-arm64.sh` that cross-builds via QEMU and switches
+the manifest from `build:` to pinned `image:` refs. It works but is manual,
+easy to forget on redeploys, and lives outside the CLI.
+
+## Goal
+
+Make `banyan-cli` build images for the architecture(s) the target agents
+actually run, so `build:` services work on a mixed-arch cluster without manual
+scripts. Cross-arch builds use QEMU emulation on the machine that runs the CLI
+(team decision — no remote builder).
+
+## Non-goals
+
+- **Remote build on the agent.** Considered and rejected in favor of local QEMU
+  emulation. May be revisited later; the builder logic is kept behind a single
+  build function so a remote implementation could slot in without touching the
+  deploy flow.
+- **MySQL 5.7 → 8.0 migration** for takahiro-dev. That is an operational task
+  (`mysqldump` → `scp` → import), not part of this CLI feature.
+- **Arch-aware scheduler changes.** Not needed — a single multi-arch OCI image
+  index resolves the right layers at pull time on the agent (see Approach).
+- **New multi-arch E2E test.** Requires a real mixed-arch cluster; out of scope.
+  Coverage is unit + proto round-trip; the gap is stated explicitly below.
+
+## Approach
+
+Architecture becomes an agent-declared attribute that flows up to the engine;
+the CLI reads it and builds the right platform(s). No layer has to guess.
+
+```
+agent (runtime.GOARCH)
+   │  Register  (new `arch` field)
+   ▼
+engine  → NodeRecord.Arch (etcd)  → ListAgents / GetInfo expose arch
+   ▲
+   │  GetInfo / ListAgents  (CLI asks before building)
+CLI `up`
+   │  compute per-service platform set
+   ▼
+nerdctl build --platform=<set>  →  push --all-platforms  →  registry (1 tag = OCI index)
+   ▼
+agent pulls its own arch (containerd selects from the index)
+```
+
+### Per-service platform resolution (CLI)
+
+For each service with a `build:` config, the CLI picks the target platform set
+in this precedence order:
+
+1. **Explicit `platform:` on the service** → use it verbatim (manual override,
+   wins over everything). *(Phase 1)*
+2. **`placement.node: X`** → the arch of node X.
+3. **`deploy` with tags** → union of the arch of all agents matching the tags.
+4. **No placement constraint** → union of **all** cluster agent arches (the
+   image must run wherever the scheduler places it).
+5. **Engine unreachable, or matched agents report no arch (old agents)** →
+   **build host arch + a warning**. This preserves offline `--dry-run`.
+
+### Why a single multi-arch index (not per-arch tags)
+
+`nerdctl build --platform=linux/amd64,linux/arm64` + `nerdctl push
+--all-platforms` produces one tag holding an OCI image index. containerd on the
+agent automatically pulls the matching arch. Confirmed available on the
+installed toolchain (nerdctl 2.1.3 exposes `build --platform strings` and `push
+--all-platforms`; BuildKit 0.19). The engine, reconciler, and scheduler keep
+deploying a single image reference unchanged — no scheduler work, and it stays
+correct even for external `image:` refs that are already multi-arch.
+
+### Deploy-flow reordering
+
+Today `runDeploy` builds at `deploy.go:147`, *before* the engine client exists
+(created ~`:180`). Phase 2 needs the agent arch map before building, so the flow
+is reordered:
+
+```
+parse manifest → connect engine (if configured) → GetInfo/ListAgents
+  → build arch map → resolve per-service platforms → build --platform
+  → push --all-platforms → deploy
+```
+
+`--dry-run` and the engine-offline branch still build, using the host-arch
+fallback (rule 5), so offline validation keeps working.
+
+## Phasing
+
+### Phase 1 — manual declaration + preflight (unblocks takahiro-dev now)
+
+No proto/engine changes. Small diff.
+
+| File | Change |
+|---|---|
+| `pkg/types/manifest.go` | Add `Platform string \`yaml:"platform,omitempty"\`` to `ManifestService`. Empty = current behavior. |
+| `cmd/banyan-cli/cmd/deploy.go` | `buildImageArgs`/`buildImage` (108, 314) take a `platform` arg; when set, insert `--platform=<p>`. Add a global `--platform` flag on `up` to override all build services. |
+| `cmd/banyan-cli/cmd/deploy.go` | `pushImage`: when a service was built for a non-host platform, push with `--all-platforms` so the index is pushed. |
+| `cmd/banyan-cli/cmd/preflight.go` (new) | Before a cross-arch build, check `/proc/sys/fs/binfmt_misc/qemu-<arch>`. If missing, error with clear instructions (run `install-deps.sh`, or `nerdctl run --privileged --rm tonistiigi/binfmt --install <arch>`). |
+| `install-deps.sh` | Add `install_qemu_binfmt()` (installs `qemu-user-static` + `binfmt-support`, or runs `tonistiigi/binfmt`). Invoke it for `ROLE=cli`/`all`. Replaces the "install buildx" idea — the stack is buildkit, not Docker, so buildx does not apply; QEMU binfmt is what is actually missing. |
+| `docs/` | Document `platform:` in the manifest and the QEMU requirement. |
+
+Result: takahiro-dev drops the manual `build-arm64.sh`, returns to `build:` in
+`banyan.yaml` with `platform: linux/arm64` on the four app services, and
+`banyan-cli up` cross-builds automatically.
+
+### Phase 2 — auto-detect arch from the cluster
+
+| File | Change |
+|---|---|
+| `pkg/rpc/proto/banyan/v1/engine.proto` | Add `string arch = 7;` to `RegisterRequest` (81) and `string arch = 5;` to `AgentInfo` (323). Not on Heartbeat — arch is static, only needed at Register. Regenerate `.pb.go`. |
+| `pkg/agent/engine_client.go` | `RegisterRequest` struct (101) + call site (110): set `Arch: runtime.GOARCH`. |
+| `pkg/types/records.go` | `NodeRecord` (134): add `Arch string \`json:"arch,omitempty"\``. |
+| `pkg/engine/grpc_handlers_agent.go` | Register handler (~46): store `node.Arch = req.Arch`. |
+| `pkg/engine/grpc_handlers_cli.go` | `ListAgents`/`GetInfo` (232, 309): return `Arch` in `AgentInfo`. |
+| `cmd/banyan-cli/cmd/deploy.go` | Reorder `runDeploy` (connect → GetInfo/ListAgents → node→arch map → apply the resolution rules → build). Host-arch fallback + warning on offline / unknown arch. |
+
+`platform:` from Phase 1 becomes the manual override in the precedence rules —
+not discarded.
+
+### Compatibility (degrade gracefully — decided)
+
+Old agents send `arch=""`. The CLI treats such a node as unknown: if the
+service has no explicit `platform:`, it builds host-arch and warns — "agent X
+did not report arch; building for <host>; upgrade the agent or set `platform:`".
+Nobody breaks on a version-skewed upgrade (this includes the live takahiro-dev
+cluster).
+
+## Testing
+
+- **Unit:** `buildImageArgs` emits the correct `--platform`; platform-set
+  resolution table (has placement / has tags / no constraint / offline / mixed
+  arch); preflight detects missing binfmt.
+- **Proto round-trip:** agent sets arch → engine stores → `ListAgents` returns
+  it.
+- **No new E2E** — a mixed-arch cluster is not available in CI. This is an
+  explicit coverage gap; manual verification is the takahiro-dev deploy itself.
+
+## Open items
+
+None blocking. The MySQL 5.7→8.0 data migration for takahiro-dev is tracked
+separately as an operational step, not part of this feature.

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -5,6 +5,10 @@
 # This file is NOT meant to be run directly.
 
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+# Directory on sudo's secure_path where the banyan commands are exposed via
+# symlink, so `sudo banyan-*` resolves even when INSTALL_DIR (e.g.
+# /usr/local/bin) is not on sudo's secure_path (default on RHEL/Oracle/Fedora).
+LINK_DIR="${LINK_DIR:-/usr/sbin}"
 
 # Dependency versions
 NERDCTL_VERSION="2.1.3"
@@ -25,6 +29,28 @@ info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 fatal() { error "$*"; exit 1; }
+
+# link_secure_path exposes an installed binary on sudo's secure_path by
+# symlinking it from INSTALL_DIR into LINK_DIR (default /usr/sbin). On RHEL/
+# Oracle/Fedora, sudo's secure_path excludes /usr/local/bin, so `sudo banyan-*`
+# fails with command-not-found even though the binary is installed. /usr/sbin
+# and /usr/bin are on the default secure_path of every supported OS.
+#
+# It never clobbers a real file: if LINK_DIR/<name> already exists as a regular
+# file (distro package, user-placed), it is left untouched with a warning. An
+# existing symlink (ours) is refreshed idempotently.
+link_secure_path() {
+    local name=$1
+    [ "$LINK_DIR" = "$INSTALL_DIR" ] && return 0   # avoid self-referential link
+    [ -d "$LINK_DIR" ] || return 0                 # skip if target dir absent
+    local target="${LINK_DIR}/${name}"
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+        warn "${target} is a real file — skipping symlink; use ${INSTALL_DIR}/${name} or the full path"
+        return 0
+    fi
+    ln -sf "${INSTALL_DIR}/${name}" "$target"
+    info "Linked ${target} -> ${INSTALL_DIR}/${name} (so 'sudo ${name}' works)"
+}
 
 # --- OS Family Registry ---
 

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -367,6 +367,36 @@ UNIT
     fi
 }
 
+install_qemu_binfmt() {
+    # Cross-arch image builds run foreign binaries under QEMU user emulation,
+    # registered via binfmt_misc. Needed on any box that cross-builds (e.g. an
+    # amd64 build host targeting arm64 agents).
+    if [ -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ] && [ -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]; then
+        info "QEMU binfmt handlers already registered, skipping."
+        return
+    fi
+
+    info "Installing QEMU user-static emulation (for cross-arch builds)..."
+
+    local family
+    family=$(get_family)
+    if [ "$family" = "debian" ]; then
+        $PKG_UPDATE
+        $PKG_INSTALL qemu-user-static binfmt-support
+    else
+        $PKG_INSTALL qemu-user-static
+    fi
+
+    # Register handlers for all arches with the buildkit/containerd worker.
+    # tonistiigi/binfmt is the most reliable cross-distro registrar.
+    if command -v nerdctl &>/dev/null; then
+        nerdctl run --privileged --rm tonistiigi/binfmt --install all >/dev/null 2>&1 || \
+            warn "tonistiigi/binfmt registration failed; qemu-user-static package handlers will be used."
+    fi
+
+    info "QEMU binfmt emulation installed."
+}
+
 # --- Systemd services ---
 
 install_systemd_services() {
@@ -589,6 +619,7 @@ install_deps() {
         install_cni
         install_wireguard
         install_buildkit
+        install_qemu_binfmt  # For cross-arch image builds
         install_nfs_client  # For NFS volume mounts
     fi
 

--- a/install-from-source.sh
+++ b/install-from-source.sh
@@ -41,6 +41,11 @@ fi
 source "$DEPS_FILE"
 [ -n "$DEPS_TMP" ] && rm -f "$DEPS_TMP"
 
+# INSTALL_DIR / LINK_DIR are provided by install-deps.sh; re-assert defaults
+# here so this script is correct on its own even if sourcing is reordered.
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+LINK_DIR="${LINK_DIR:-/usr/sbin}"
+
 # --- Build from source ---
 
 build_binary() {
@@ -65,6 +70,7 @@ build_binary() {
     mv "$tmp" "${INSTALL_DIR}/${name}"
 
     info "${name} installed to ${INSTALL_DIR}/${name} (built from source)"
+    link_secure_path "$name"
 }
 
 build_web_dashboard() {

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,11 @@ fi
 source "$DEPS_FILE"
 [ -n "$DEPS_TMP" ] && rm -f "$DEPS_TMP"
 
+# INSTALL_DIR / LINK_DIR are provided by install-deps.sh; re-assert defaults
+# here so this script is correct on its own even if sourcing is reordered.
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+LINK_DIR="${LINK_DIR:-/usr/sbin}"
+
 # --- Release binary installation ---
 
 get_latest_version() {
@@ -108,6 +113,7 @@ install_binary() {
     mv "$tmp" "${INSTALL_DIR}/${name}"
 
     info "${name} ${BANYAN_VERSION} installed to ${INSTALL_DIR}/${name}"
+    link_secure_path "$name"
 }
 
 install_banyan() {

--- a/pkg/agent/engine_client.go
+++ b/pkg/agent/engine_client.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -113,6 +114,7 @@ func (ec *EngineClient) Register(ctx context.Context, req RegisterRequest) (stri
 		Tags:        req.Tags,
 		WgPublicKey: req.WGPublicKey,
 		HostIp:      req.HostIP,
+		Arch:        runtime.GOARCH,
 	})
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("register failed: %w", err)

--- a/pkg/agent/engine_client_test.go
+++ b/pkg/agent/engine_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -608,4 +609,64 @@ func TestEngineClient_ErrorPaths(t *testing.T) {
 			t.Error("expected error from Health on stopped server")
 		}
 	})
+}
+
+// archCaptureTestEngineServer records the Arch field of the last RegisterRequest it received.
+type archCaptureTestEngineServer struct {
+	banyanpb.UnimplementedEngineServiceServer
+	registryURL string
+	gotArch     string
+}
+
+func (s *archCaptureTestEngineServer) Register(ctx context.Context, req *banyanpb.RegisterRequest) (*banyanpb.RegisterResponse, error) {
+	s.gotArch = req.Arch
+	return &banyanpb.RegisterResponse{RegistryUrl: s.registryURL}, nil
+}
+
+func (s *archCaptureTestEngineServer) Health(ctx context.Context, req *banyanpb.HealthRequest) (*banyanpb.HealthResponse, error) {
+	return &banyanpb.HealthResponse{Status: "ok"}, nil
+}
+
+func TestEngineClient_Register_SendsArch(t *testing.T) {
+	lis := bufconn.Listen(testBufSize)
+	srv := grpc.NewServer()
+
+	engineSrv := &archCaptureTestEngineServer{registryURL: "localhost:5000"}
+	banyanpb.RegisterEngineServiceServer(srv, engineSrv)
+
+	go func() {
+		if err := srv.Serve(lis); err != nil {
+			t.Logf("server error: %v", err)
+		}
+	}()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer func() {
+		conn.Close()
+		srv.Stop()
+	}()
+
+	client := &EngineClient{
+		endpoints: []string{"passthrough:///bufnet"},
+		conn:      conn,
+		client:    banyanpb.NewEngineServiceClient(conn),
+	}
+
+	_, _, _, err = client.Register(context.Background(), RegisterRequest{
+		Name: "worker-1", APIAddr: "worker-1:50052",
+	})
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	if engineSrv.gotArch != runtime.GOARCH {
+		t.Errorf("expected arch %q, got %q", runtime.GOARCH, engineSrv.gotArch)
+	}
 }

--- a/pkg/agent/vpc_networking.go
+++ b/pkg/agent/vpc_networking.go
@@ -615,6 +615,21 @@ func (a *Agent) initializeDNS(ctx context.Context, allocatedSubnet string) error
 	return nil
 }
 
+// effectiveBackendIP returns the IP to register in DNS for a backend. For a
+// container running on THIS agent it re-inspects the live container so DNS
+// reflects the real current IP (the engine's stored task IP is set at create
+// time and can go stale after the container's network is recreated, e.g. across
+// an agent or container restart). Remote backends, and locals we can't inspect,
+// fall back to the engine-reported IP.
+func (a *Agent) effectiveBackendIP(ctx context.Context, b ServiceBackend) string {
+	if b.AgentName == a.opts.AgentName && b.ContainerName != "" {
+		if ip, err := containerIPGetter(ctx, b.ContainerName); err == nil && ip != "" {
+			return ip
+		}
+	}
+	return b.ContainerIP
+}
+
 // reconcileDNS updates the DNS manager with the current set of service backends.
 // DNS entries are scoped by deployment: each service registers as
 // <service>.<deployment>.internal (fully qualified). The short name
@@ -629,7 +644,16 @@ func (a *Agent) reconcileDNS(ctx context.Context, backends []ServiceBackend) {
 	// Register both deployment-scoped and short names
 	desired := map[string]map[string]bool{}
 	for _, b := range backends {
-		if b.ServiceName == "" || b.ContainerIP == "" {
+		if b.ServiceName == "" {
+			continue
+		}
+
+		// Use the container's REAL current IP for backends on this agent (the
+		// engine-reported task IP is captured at create time and goes stale if
+		// the container's network is later recreated); remote backends keep the
+		// engine-reported IP. This makes DNS self-heal every heartbeat.
+		ip := a.effectiveBackendIP(ctx, b)
+		if ip == "" {
 			continue
 		}
 
@@ -639,7 +663,7 @@ func (a *Agent) reconcileDNS(ctx context.Context, backends []ServiceBackend) {
 			if desired[fqdn] == nil {
 				desired[fqdn] = map[string]bool{}
 			}
-			desired[fqdn][b.ContainerIP] = true
+			desired[fqdn][ip] = true
 		}
 
 		// Register the short name <service>.internal only if there's no conflict
@@ -648,7 +672,7 @@ func (a *Agent) reconcileDNS(ctx context.Context, backends []ServiceBackend) {
 		if desired[shortName] == nil {
 			desired[shortName] = map[string]bool{}
 		}
-		desired[shortName][b.ContainerIP] = true
+		desired[shortName][ip] = true
 	}
 
 	// Check for short name conflicts: if multiple deployments have the same

--- a/pkg/agent/vpc_networking.go
+++ b/pkg/agent/vpc_networking.go
@@ -113,6 +113,31 @@ func defaultSetupOverlayForwarding() error {
 	return nil
 }
 
+// dnsInputRules returns the two INPUT rulespecs (udp + tcp) that accept DNS
+// queries addressed to the bridge gateway IP, where the in-agent DNS server
+// listens. Kept in one place so setup and teardown stay in sync.
+func dnsInputRules(gatewayIP string) [][]string {
+	rules := make([][]string, 0, 2)
+	for _, proto := range []string{"udp", "tcp"} {
+		rules = append(rules, []string{
+			"-i", "banyan0", "-d", gatewayIP, "-p", proto, "--dport", "53", "-j", "ACCEPT",
+		})
+	}
+	return rules
+}
+
+// ensureDNSInputAccept idempotently inserts the INPUT ACCEPT rules for
+// container→gateway DNS. Inserted at the top of INPUT so it wins over a
+// restrictive host firewall's reject rule. Safe to call repeatedly.
+func ensureDNSInputAccept(ipt iptablesHandle, gatewayIP string) {
+	for _, rule := range dnsInputRules(gatewayIP) {
+		exists, _ := ipt.Exists("filter", "INPUT", rule...)
+		if !exists {
+			_ = ipt.Insert("filter", "INPUT", 1, rule...)
+		}
+	}
+}
+
 // depChainName returns the iptables chain name for a deployment.
 // Truncates to fit the 28-character iptables chain name limit.
 func depChainName(deploymentName string) string {
@@ -170,12 +195,26 @@ func (a *Agent) reconcileNetworkIsolation(ctx context.Context, backends []Servic
 		return
 	}
 
-	// 4. Allow DNS to gateway IP
+	// 4. Allow DNS to gateway IP.
+	//
+	// Two distinct rules are needed for two distinct packet paths:
+	//   - BANYAN-ISOLATION (reached only from FORWARD) covers DNS queries that
+	//     traverse the host between banyan0 and banyan-wg (cross-node overlay).
+	//   - INPUT covers DNS queries a container sends to the in-agent DNS server,
+	//     which is bound to the bridge gateway IP. That IP is local to the host,
+	//     so the packet is delivered locally and hits INPUT — it never passes
+	//     through FORWARD/BANYAN-ISOLATION. Without an explicit INPUT ACCEPT, a
+	//     restrictive host firewall (e.g. firewalld's default reject-with
+	//     icmp-host-prohibited on RHEL/Oracle Linux) drops it and containers
+	//     cannot resolve *.internal names.
 	if a.gatewayIP != "" {
 		for _, proto := range []string{"udp", "tcp"} {
 			_ = ipt.Append("filter", isolationChainName,
 				"-d", a.gatewayIP, "-p", proto, "--dport", "53", "-j", "ACCEPT")
 		}
+		// Ensure the INPUT ACCEPT idempotently. reconcileNetworkIsolation runs
+		// on every heartbeat, so this self-heals if a firewalld reload flushes it.
+		ensureDNSInputAccept(ipt, a.gatewayIP)
 	}
 
 	// 5. Create per-deployment chains and populate
@@ -286,6 +325,13 @@ func (a *Agent) cleanupStaleNetworking() {
 	// Clear and delete BANYAN-ISOLATION chain
 	ipt.ClearChain("filter", isolationChainName) //nolint:errcheck // best-effort
 	ipt.DeleteChain("filter", isolationChainName) //nolint:errcheck // best-effort
+
+	// NOTE: the DNS INPUT ACCEPT rules (see ensureDNSInputAccept) are intentionally
+	// not force-removed here. The gateway IP of the *previous* run is unknown at this
+	// point (it is derived from the allocated subnet, assigned later), so there is
+	// nothing precise to delete. The rules are idempotent and re-asserted every
+	// heartbeat by reconcileNetworkIsolation, and the gateway IP is stable for a
+	// given subnet, so they neither duplicate nor leak on a normal restart.
 
 	// Clean up BN-DEP-* chains
 	chains, listErr := ipt.ListChains("filter")

--- a/pkg/agent/vpc_networking_test.go
+++ b/pkg/agent/vpc_networking_test.go
@@ -1369,6 +1369,50 @@ func TestReconcileDNS(t *testing.T) {
 		}
 	})
 
+	t.Run("uses real inspected IP for local backends", func(t *testing.T) {
+		origGetter := containerIPGetter
+		t.Cleanup(func() { containerIPGetter = origGetter })
+		// Local container's real current IP differs from the stale engine-reported one.
+		containerIPGetter = func(_ context.Context, name string) (string, error) {
+			if name == "taka-backend-0" {
+				return "10.0.1.50", nil
+			}
+			return "", os.ErrNotExist
+		}
+
+		manager := dns.NewManager()
+		a := &Agent{
+			opts:          Options{AgentName: "agent-local"},
+			dnsManager:    manager,
+			registeredDNS: make(map[string]bool),
+		}
+
+		backends := []ServiceBackend{
+			// local: engine says .78 (stale) but real is .50 → DNS must use .50
+			{ContainerName: "taka-backend-0", ContainerIP: "10.0.1.78", ServiceName: "backend", DeploymentName: "taka", AgentName: "agent-local"},
+			// remote: keep the engine-reported IP as-is
+			{ContainerName: "taka-web-0", ContainerIP: "10.0.9.9", ServiceName: "web", DeploymentName: "taka", AgentName: "agent-remote"},
+		}
+
+		a.reconcileDNS(context.Background(), backends)
+
+		ctx := context.Background()
+		ips, err := manager.LookupHost(ctx, "backend.taka.internal")
+		if err != nil {
+			t.Fatalf("LookupHost backend.taka.internal failed: %v", err)
+		}
+		if len(ips) != 1 || ips[0].String() != "10.0.1.50" {
+			t.Fatalf("expected local backend to resolve to real IP [10.0.1.50], got %v", ips)
+		}
+		ips, err = manager.LookupHost(ctx, "web.taka.internal")
+		if err != nil {
+			t.Fatalf("LookupHost web.taka.internal failed: %v", err)
+		}
+		if len(ips) != 1 || ips[0].String() != "10.0.9.9" {
+			t.Fatalf("expected remote backend to keep engine IP [10.0.9.9], got %v", ips)
+		}
+	})
+
 	t.Run("no-op when manager is nil", func(t *testing.T) {
 		a := &Agent{
 			dnsManager:    nil,

--- a/pkg/agent/vpc_networking_test.go
+++ b/pkg/agent/vpc_networking_test.go
@@ -498,6 +498,19 @@ func TestReconcileNetworkIsolation(t *testing.T) {
 			t.Error("expected DNS allow rule for gateway IP")
 		}
 
+		// Verify DNS is also allowed on the INPUT chain (container→gateway path).
+		// This is inserted (not appended to the isolation chain), so scan inserts.
+		foundInputDNS := false
+		for _, rule := range mock.inserted {
+			if containsAll(rule, "-i", "banyan0", "-d", "10.0.1.1", "-p", "udp", "--dport", "53", "-j", "ACCEPT") {
+				foundInputDNS = true
+				break
+			}
+		}
+		if !foundInputDNS {
+			t.Error("expected INPUT ACCEPT rule for container→gateway DNS")
+		}
+
 		// Verify deployment chains have the right allow rules
 		myappRules := mock.appended[depMyapp]
 		foundWeb1 := false
@@ -665,6 +678,40 @@ func TestAddContainerToIsolation(t *testing.T) {
 		// First insert: allow rule in deployment chain
 		if !containsAll(mock.inserted[0], "-d", "10.0.1.6", "-j", "ACCEPT") {
 			t.Errorf("expected allow rule in dep chain, got: %v", mock.inserted[0])
+		}
+	})
+}
+
+func TestEnsureDNSInputAccept(t *testing.T) {
+	t.Run("inserts udp and tcp rules when absent", func(t *testing.T) {
+		mock := &mockIPTables{} // existsResult false → both rules inserted
+
+		ensureDNSInputAccept(mock, "10.0.1.1")
+
+		if len(mock.inserted) != 2 {
+			t.Fatalf("expected 2 Insert calls, got %d", len(mock.inserted))
+		}
+		foundUDP, foundTCP := false, false
+		for _, rule := range mock.inserted {
+			if containsAll(rule, "-i", "banyan0", "-d", "10.0.1.1", "-p", "udp", "--dport", "53", "-j", "ACCEPT") {
+				foundUDP = true
+			}
+			if containsAll(rule, "-i", "banyan0", "-d", "10.0.1.1", "-p", "tcp", "--dport", "53", "-j", "ACCEPT") {
+				foundTCP = true
+			}
+		}
+		if !foundUDP || !foundTCP {
+			t.Errorf("expected both udp and tcp INPUT rules, udp=%v tcp=%v", foundUDP, foundTCP)
+		}
+	})
+
+	t.Run("is idempotent when rules already exist", func(t *testing.T) {
+		mock := &mockIPTables{existsResult: true}
+
+		ensureDNSInputAccept(mock, "10.0.1.1")
+
+		if len(mock.inserted) != 0 {
+			t.Errorf("expected 0 Insert calls when rules exist, got %d", len(mock.inserted))
 		}
 	})
 }

--- a/pkg/engine/grpc_handlers_agent.go
+++ b/pkg/engine/grpc_handlers_agent.go
@@ -43,6 +43,7 @@ func (s *engineGRPCServer) Register(ctx context.Context, req *banyanpb.RegisterR
 		Name:       req.AgentName,
 		Status:     "ready",
 		APIAddress: req.ApiAddress,
+		Arch:       req.Arch,
 		Tags:       req.Tags,
 		LastSeen:   time.Now(),
 		CreatedAt:  time.Now(),

--- a/pkg/engine/grpc_handlers_cli.go
+++ b/pkg/engine/grpc_handlers_cli.go
@@ -230,6 +230,7 @@ func (s *engineGRPCServer) GetStatus(ctx context.Context, req *banyanpb.GetStatu
 			LastSeenUnix:  node.LastSeen.Unix(),
 			CreatedAtUnix: node.CreatedAt.Unix(),
 			Tags:          node.Tags,
+			Arch:          node.Arch,
 		})
 	}
 

--- a/pkg/engine/grpc_server_test.go
+++ b/pkg/engine/grpc_server_test.go
@@ -822,6 +822,33 @@ func TestGetStatus(t *testing.T) {
 	})
 }
 
+func TestGetStatus_ReturnsAgentArch(t *testing.T) {
+	client, srv, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	node := &types.NodeRecord{Name: "worker-1", Status: "ready", Arch: "arm64", LastSeen: time.Now(), CreatedAt: time.Now()}
+	srv.store.Save(ctx, types.KeyNodes+"worker-1", node)
+
+	resp, err := client.GetStatus(ctx, &banyanpb.GetStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetStatus failed: %v", err)
+	}
+	var found *banyanpb.AgentInfo
+	for _, a := range resp.Agents {
+		if a.Name == "worker-1" {
+			found = a
+		}
+	}
+	if found == nil {
+		t.Fatal("worker-1 not in agents")
+	}
+	if found.Arch != "arm64" {
+		t.Errorf("expected arch arm64, got %q", found.Arch)
+	}
+}
+
 func TestGetInfo(t *testing.T) {
 	client, _, cleanup := setupTestServer(t)
 	defer cleanup()
@@ -1747,6 +1774,29 @@ func TestRegister_SaveError(t *testing.T) {
 	}
 	if status.Code(err) != codes.Internal {
 		t.Errorf("expected Internal, got %v", status.Code(err))
+	}
+}
+
+func TestRegister_PersistsArch(t *testing.T) {
+	store := storage.NewMemoryStore()
+	srv := &engineGRPCServer{store: store, registryURL: "localhost:5000"}
+
+	ctx := context.Background()
+	_, err := srv.Register(ctx, &banyanpb.RegisterRequest{
+		AgentName:  "worker-1",
+		ApiAddress: "10.0.0.5:9100",
+		Arch:       "arm64",
+	})
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	var node types.NodeRecord
+	if err := store.Get(ctx, types.KeyNodes+"worker-1", &node); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if node.Arch != "arm64" {
+		t.Errorf("expected arch arm64, got %q", node.Arch)
 	}
 }
 

--- a/pkg/rpc/banyanpb/engine.pb.go
+++ b/pkg/rpc/banyanpb/engine.pb.go
@@ -233,6 +233,7 @@ type RegisterRequest struct {
 	Tags          []string               `protobuf:"bytes,4,rep,name=tags,proto3" json:"tags,omitempty"`
 	WgPublicKey   string                 `protobuf:"bytes,5,opt,name=wg_public_key,json=wgPublicKey,proto3" json:"wg_public_key,omitempty"` // agent's WireGuard public key
 	HostIp        string                 `protobuf:"bytes,6,opt,name=host_ip,json=hostIp,proto3" json:"host_ip,omitempty"`                  // agent's data-plane host IP (for overlay peer endpoint)
+	Arch          string                 `protobuf:"bytes,7,opt,name=arch,proto3" json:"arch,omitempty"`                                    // agent's CPU arch (runtime.GOARCH: "amd64" | "arm64")
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -305,6 +306,13 @@ func (x *RegisterRequest) GetWgPublicKey() string {
 func (x *RegisterRequest) GetHostIp() string {
 	if x != nil {
 		return x.HostIp
+	}
+	return ""
+}
+
+func (x *RegisterRequest) GetArch() string {
+	if x != nil {
+		return x.Arch
 	}
 	return ""
 }
@@ -2589,6 +2597,7 @@ type AgentInfo struct {
 	LastSeenUnix  int64                  `protobuf:"varint,4,opt,name=last_seen_unix,json=lastSeenUnix,proto3" json:"last_seen_unix,omitempty"`
 	CreatedAtUnix int64                  `protobuf:"varint,5,opt,name=created_at_unix,json=createdAtUnix,proto3" json:"created_at_unix,omitempty"`
 	Tags          []string               `protobuf:"bytes,6,rep,name=tags,proto3" json:"tags,omitempty"`
+	Arch          string                 `protobuf:"bytes,7,opt,name=arch,proto3" json:"arch,omitempty"` // agent's CPU arch, empty if agent predates arch reporting
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2663,6 +2672,13 @@ func (x *AgentInfo) GetTags() []string {
 		return x.Tags
 	}
 	return nil
+}
+
+func (x *AgentInfo) GetArch() string {
+	if x != nil {
+		return x.Arch
+	}
+	return ""
 }
 
 type DeploymentInfo struct {
@@ -5911,7 +5927,7 @@ const file_engine_proto_rawDesc = "" +
 	"\x12memory_total_bytes\x18\x03 \x01(\x04R\x10memoryTotalBytes\x12&\n" +
 	"\x0fdisk_used_bytes\x18\x04 \x01(\x04R\rdiskUsedBytes\x12(\n" +
 	"\x10disk_total_bytes\x18\x05 \x01(\x04R\x0ediskTotalBytes\x12\x1b\n" +
-	"\tcpu_cores\x18\x06 \x01(\rR\bcpuCores\"\xc7\x01\n" +
+	"\tcpu_cores\x18\x06 \x01(\rR\bcpuCores\"\xdb\x01\n" +
 	"\x0fRegisterRequest\x12\x1d\n" +
 	"\n" +
 	"agent_name\x18\x01 \x01(\tR\tagentName\x12\x1f\n" +
@@ -5920,7 +5936,8 @@ const file_engine_proto_rawDesc = "" +
 	"\rsession_token\x18\x03 \x01(\tR\fsessionToken\x12\x12\n" +
 	"\x04tags\x18\x04 \x03(\tR\x04tags\x12\"\n" +
 	"\rwg_public_key\x18\x05 \x01(\tR\vwgPublicKey\x12\x17\n" +
-	"\ahost_ip\x18\x06 \x01(\tR\x06hostIp\"\x98\x02\n" +
+	"\ahost_ip\x18\x06 \x01(\tR\x06hostIp\x12\x12\n" +
+	"\x04arch\x18\a \x01(\tR\x04arch\"\x98\x02\n" +
 	"\x10RegisterResponse\x12!\n" +
 	"\fregistry_url\x18\x01 \x01(\tR\vregistryUrl\x12+\n" +
 	"\x0fstore_endpoints\x18\x02 \x03(\tB\x02\x18\x01R\x0estoreEndpoints\x12\x19\n" +
@@ -6122,7 +6139,7 @@ const file_engine_proto_rawDesc = "" +
 	"\x10GetStatusRequest\"~\n" +
 	"\x11GetStatusResponse\x12,\n" +
 	"\x06agents\x18\x01 \x03(\v2\x14.banyan.v1.AgentInfoR\x06agents\x12;\n" +
-	"\vdeployments\x18\x02 \x03(\v2\x19.banyan.v1.DeploymentInfoR\vdeployments\"\xba\x01\n" +
+	"\vdeployments\x18\x02 \x03(\v2\x19.banyan.v1.DeploymentInfoR\vdeployments\"\xce\x01\n" +
 	"\tAgentInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1f\n" +
@@ -6130,7 +6147,8 @@ const file_engine_proto_rawDesc = "" +
 	"apiAddress\x12$\n" +
 	"\x0elast_seen_unix\x18\x04 \x01(\x03R\flastSeenUnix\x12&\n" +
 	"\x0fcreated_at_unix\x18\x05 \x01(\x03R\rcreatedAtUnix\x12\x12\n" +
-	"\x04tags\x18\x06 \x03(\tR\x04tags\"\xe0\x03\n" +
+	"\x04tags\x18\x06 \x03(\tR\x04tags\x12\x12\n" +
+	"\x04arch\x18\a \x01(\tR\x04arch\"\xe0\x03\n" +
 	"\x0eDeploymentInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x16\n" +

--- a/pkg/rpc/proto/banyan/v1/engine.proto
+++ b/pkg/rpc/proto/banyan/v1/engine.proto
@@ -85,6 +85,7 @@ message RegisterRequest {
   repeated string tags = 4;
   string wg_public_key = 5;       // agent's WireGuard public key
   string host_ip = 6;             // agent's data-plane host IP (for overlay peer endpoint)
+  string arch = 7;                // agent's CPU arch (runtime.GOARCH: "amd64" | "arm64")
 }
 
 message RegisterResponse {
@@ -327,6 +328,7 @@ message AgentInfo {
   int64 last_seen_unix = 4;
   int64 created_at_unix = 5;
   repeated string tags = 6;
+  string arch = 7;                // agent's CPU arch, empty if agent predates arch reporting
 }
 
 message DeploymentInfo {

--- a/pkg/types/manifest.go
+++ b/pkg/types/manifest.go
@@ -113,6 +113,7 @@ type BanyanManifest struct {
 type ManifestService struct {
 	Image       string               `yaml:"image"`
 	Build       *ManifestBuild       `yaml:"build,omitempty"`
+	Platform    string               `yaml:"platform,omitempty"` // e.g., "linux/arm64"; empty = build host arch (or auto-detect)
 	Deploy      *ManifestDeploy      `yaml:"deploy,omitempty"`
 	Healthcheck *ManifestHealthcheck `yaml:"healthcheck,omitempty"`
 	Ports       []string             `yaml:"ports,omitempty"`

--- a/pkg/types/manifest_test.go
+++ b/pkg/types/manifest_test.go
@@ -1031,3 +1031,27 @@ func TestVolumeMount_BuildServiceRecords(t *testing.T) {
 		t.Error("expected second volume to be read-only")
 	}
 }
+
+func TestManifestService_PlatformParses(t *testing.T) {
+	src := `
+image: myimg:latest
+platform: linux/arm64
+`
+	var svc ManifestService
+	if err := yaml.Unmarshal([]byte(src), &svc); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if svc.Platform != "linux/arm64" {
+		t.Errorf("expected platform linux/arm64, got %q", svc.Platform)
+	}
+}
+
+func TestManifestService_PlatformOmittedIsEmpty(t *testing.T) {
+	var svc ManifestService
+	if err := yaml.Unmarshal([]byte("image: myimg:latest\n"), &svc); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if svc.Platform != "" {
+		t.Errorf("expected empty platform, got %q", svc.Platform)
+	}
+}

--- a/pkg/types/records.go
+++ b/pkg/types/records.go
@@ -137,6 +137,7 @@ type NodeRecord struct {
 	Name             string    `json:"name"`
 	Status           string    `json:"status"`
 	APIAddress       string    `json:"api_address,omitempty"`
+	Arch             string    `json:"arch,omitempty"`
 	Tags             []string  `json:"tags,omitempty"`
 	MemoryTotalBytes uint64    `json:"memory_total_bytes,omitempty"`
 	MemoryUsedBytes  uint64    `json:"memory_used_bytes,omitempty"`

--- a/test/os-compat/test-link-secure-path.sh
+++ b/test/os-compat/test-link-secure-path.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Unit tests for link_secure_path() in install-deps.sh.
+# Sources the library and exercises the function against temp dirs.
+# No network, no root required.
+#
+# Run: bash test/os-compat/test-link-secure-path.sh
+
+# NOTE: deliberately no `set -e` — some cases assert a command's exit code.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# install-deps.sh is a sourced library (only var/function definitions at top
+# level), so sourcing it here is safe.
+# shellcheck source=../../install-deps.sh
+source "${PROJECT_ROOT}/install-deps.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+WORK=""
+new_env() {
+    WORK=$(mktemp -d)
+    INSTALL_DIR="${WORK}/install"
+    LINK_DIR="${WORK}/link"
+    mkdir -p "$INSTALL_DIR" "$LINK_DIR"
+    : > "${INSTALL_DIR}/banyan-cli"
+    chmod +x "${INSTALL_DIR}/banyan-cli"
+}
+cleanup() { rm -rf "$WORK"; }
+
+# 1. Creates a symlink that resolves to INSTALL_DIR/<name>
+new_env
+link_secure_path banyan-cli >/dev/null 2>&1
+if [ -L "${LINK_DIR}/banyan-cli" ] && \
+   [ "$(readlink "${LINK_DIR}/banyan-cli")" = "${INSTALL_DIR}/banyan-cli" ]; then
+    pass "creates symlink to INSTALL_DIR"
+else
+    fail "creates symlink to INSTALL_DIR"
+fi
+cleanup
+
+# 2. Idempotent — second call keeps a correct symlink and returns 0
+new_env
+link_secure_path banyan-cli >/dev/null 2>&1
+link_secure_path banyan-cli >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && \
+   [ "$(readlink "${LINK_DIR}/banyan-cli")" = "${INSTALL_DIR}/banyan-cli" ]; then
+    pass "idempotent on repeat call"
+else
+    fail "idempotent on repeat call"
+fi
+cleanup
+
+# 3. Self-link guard — LINK_DIR == INSTALL_DIR must not replace the real file
+new_env
+LINK_DIR="$INSTALL_DIR"
+link_secure_path banyan-cli >/dev/null 2>&1
+if [ -f "${INSTALL_DIR}/banyan-cli" ] && [ ! -L "${INSTALL_DIR}/banyan-cli" ]; then
+    pass "self-link guard leaves file untouched"
+else
+    fail "self-link guard leaves file untouched"
+fi
+cleanup
+
+# 4. Missing-dir guard — absent LINK_DIR is a no-op and returns 0
+new_env
+rm -rf "$LINK_DIR"
+link_secure_path banyan-cli >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -e "${LINK_DIR}/banyan-cli" ]; then
+    pass "missing-dir guard is a no-op"
+else
+    fail "missing-dir guard is a no-op"
+fi
+cleanup
+
+# 5. Real-file guard — a pre-existing regular file is left intact
+new_env
+echo "real" > "${LINK_DIR}/banyan-cli"
+link_secure_path banyan-cli >/dev/null 2>&1
+if [ ! -L "${LINK_DIR}/banyan-cli" ] && \
+   [ "$(cat "${LINK_DIR}/banyan-cli")" = "real" ]; then
+    pass "real-file guard leaves file intact"
+else
+    fail "real-file guard leaves file intact"
+fi
+cleanup
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/website/package.json
+++ b/website/package.json
@@ -13,5 +13,6 @@
     "astro-mermaid": "^1.3.1",
     "mermaid": "^11.12.3",
     "sharp": "^0.33.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/website/src/content/docs/reference/manifest.md
+++ b/website/src/content/docs/reference/manifest.md
@@ -124,6 +124,7 @@ services:
 | `deploy.stop_grace_period` | string | No | `5s` | Time to wait after removing from proxy/DNS before stopping a container during scale-down or drain. |
 | `volumes` | list | No | -- | Mount volumes into the container. Same syntax as Docker Compose. See [volumes](#volumes) below. |
 | `secrets` | list | No | -- | Secret names to inject as environment variables. Each name must match a secret created with `banyan-cli secret create`. See [Secrets](#secrets) below. |
+| `platform` | string | No | -- | Target architecture for `build:` services (e.g., `linux/arm64`). See [Building for a specific architecture](#building-for-a-specific-architecture-platform) below. |
 
 ## Container naming
 
@@ -274,6 +275,30 @@ services:
 Each service must have either `image` or `build` (or both).
 
 The [full example](#full-example-examplesbanyanyml) above demonstrates mixing `build:` and `image:` services. Services with `build:` are built locally and pushed to the Engine's registry. Services with only `image:` are pulled directly by agents.
+
+### Building for a specific architecture (`platform:`)
+
+`banyan-cli` builds images on the machine running the CLI. If your agents run a
+different CPU architecture (e.g. arm64 Ampere servers while you build on an
+amd64 laptop), set `platform:` on each build service:
+
+```yaml
+services:
+  api:
+    build: ./api
+    platform: linux/arm64
+```
+
+Or override all build services at once:
+
+```bash
+sudo banyan-cli up --platform linux/arm64
+```
+
+Cross-arch builds run under QEMU emulation, which must be installed on the build
+box (`install-deps.sh` installs it, or run
+`sudo nerdctl run --privileged --rm tonistiigi/binfmt --install all`). If it is
+missing, `banyan-cli up` fails fast with install instructions.
 
 ### env_file
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4,7 +4,7 @@
 
 "@antfu/install-pkg@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@antfu/install-pkg/-/install-pkg-1.1.0.tgz#78fa036be1a6081b5a77a5cf59f50c7752b6ba26"
+  resolved "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz"
   integrity sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==
   dependencies:
     package-manager-detector "^1.3.0"
@@ -12,17 +12,17 @@
 
 "@astrojs/compiler@^2.13.0":
   version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-2.13.1.tgz#d3cf26ed98e19d3d100cdbeb661ce7b856719ca7"
+  resolved "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz"
   integrity sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==
 
 "@astrojs/internal-helpers@0.7.5":
   version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@astrojs/internal-helpers/-/internal-helpers-0.7.5.tgz#c1491b70a7ac00efbd0de650f3a4058e07112a31"
+  resolved "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.5.tgz"
   integrity sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==
 
 "@astrojs/markdown-remark@6.3.10":
   version "6.3.10"
-  resolved "https://registry.yarnpkg.com/@astrojs/markdown-remark/-/markdown-remark-6.3.10.tgz#75b8ce7398eec483006de8d76c604cc6ff841606"
+  resolved "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.10.tgz"
   integrity sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==
   dependencies:
     "@astrojs/internal-helpers" "0.7.5"
@@ -49,7 +49,7 @@
 
 "@astrojs/mdx@^4.0.5":
   version "4.3.13"
-  resolved "https://registry.yarnpkg.com/@astrojs/mdx/-/mdx-4.3.13.tgz#a7f6ad87df991ac7f5f9a2d26d1ad07eb3426476"
+  resolved "https://registry.npmjs.org/@astrojs/mdx/-/mdx-4.3.13.tgz"
   integrity sha512-IHDHVKz0JfKBy3//52JSiyWv089b7GVSChIXLrlUOoTLWowG3wr2/8hkaEgEyd/vysvNQvGk+QhysXpJW5ve6Q==
   dependencies:
     "@astrojs/markdown-remark" "6.3.10"
@@ -68,14 +68,14 @@
 
 "@astrojs/prism@3.3.0":
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/prism/-/prism-3.3.0.tgz#5888fcd5665d416450a4fe55b1b7b701b8d586d9"
+  resolved "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz"
   integrity sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==
   dependencies:
     prismjs "^1.30.0"
 
 "@astrojs/sitemap@^3.2.1":
   version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/sitemap/-/sitemap-3.7.0.tgz#26ffe9b2f51e2720e5e96f358ecc20f4d87f7218"
+  resolved "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.0.tgz"
   integrity sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==
   dependencies:
     sitemap "^8.0.2"
@@ -84,7 +84,7 @@
 
 "@astrojs/starlight@^0.32.0":
   version "0.32.6"
-  resolved "https://registry.yarnpkg.com/@astrojs/starlight/-/starlight-0.32.6.tgz#af6723cc3c46a5110076da88628dd340c7656efd"
+  resolved "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.32.6.tgz"
   integrity sha512-ASWGwNzq+0TmJ+GJFFxFFxx6Yra7BqIIMQbvOy/cweTHjqejB6mcaEWtS3Mag12LM7tXCES7v/fzmdPgjz8Yxw==
   dependencies:
     "@astrojs/mdx" "^4.0.5"
@@ -115,7 +115,7 @@
 
 "@astrojs/telemetry@3.3.0":
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/telemetry/-/telemetry-3.3.0.tgz#397dc1f3ab123470571d80c9b4c1335195d30417"
+  resolved "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz"
   integrity sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==
   dependencies:
     ci-info "^4.2.0"
@@ -128,29 +128,29 @@
 
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
 "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
 "@babel/parser@^7.29.0":
   version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.0.tgz#669ef345add7d057e92b7ed15f0bac07611831b6"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz"
   integrity sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==
   dependencies:
     "@babel/types" "^7.29.0"
 
 "@babel/runtime@^7.23.2":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
 "@babel/types@^7.29.0":
   version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz"
   integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
@@ -158,19 +158,19 @@
 
 "@braintree/sanitize-url@^7.1.1":
   version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz#ca2035b0fefe956a8676ff0c69af73e605fcd81f"
+  resolved "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz"
   integrity sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==
 
 "@capsizecss/unpack@^4.0.0":
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@capsizecss/unpack/-/unpack-4.0.0.tgz#d4c387acf980527cab2046aba996e709832e669e"
+  resolved "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz"
   integrity sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==
   dependencies:
     fontkitten "^1.0.0"
 
 "@chevrotain/cst-dts-gen@11.1.1":
   version "11.1.1"
-  resolved "https://registry.yarnpkg.com/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.1.tgz#4224e0bb05064f7186886b5d9371e6ea9ff29326"
+  resolved "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.1.tgz"
   integrity sha512-fRHyv6/f542qQqiRGalrfJl/evD39mAvbJLCekPazhiextEatq1Jx1K/i9gSd5NNO0ds03ek0Cbo/4uVKmOBcw==
   dependencies:
     "@chevrotain/gast" "11.1.1"
@@ -179,7 +179,7 @@
 
 "@chevrotain/gast@11.1.1":
   version "11.1.1"
-  resolved "https://registry.yarnpkg.com/@chevrotain/gast/-/gast-11.1.1.tgz#f2af299cafb9b578912880e28df20f84b8507cab"
+  resolved "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.1.tgz"
   integrity sha512-Ko/5vPEYy1vn5CbCjjvnSO4U7GgxyGm+dfUZZJIWTlQFkXkyym0jFYrWEU10hyCjrA7rQtiHtBr0EaZqvHFZvg==
   dependencies:
     "@chevrotain/types" "11.1.1"
@@ -187,294 +187,37 @@
 
 "@chevrotain/regexp-to-ast@11.1.1":
   version "11.1.1"
-  resolved "https://registry.yarnpkg.com/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.1.tgz#a413f59f82590df8d869d7c6233767aff734ba2e"
+  resolved "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.1.tgz"
   integrity sha512-ctRw1OKSXkOrR8VTvOxrQ5USEc4sNrfwXHa1NuTcR7wre4YbjPcKw+82C2uylg/TEwFRgwLmbhlln4qkmDyteg==
 
 "@chevrotain/types@11.1.1":
   version "11.1.1"
-  resolved "https://registry.yarnpkg.com/@chevrotain/types/-/types-11.1.1.tgz#cfae33d6cfb3048a1ad8fc2277ee9fcf3e9252c9"
+  resolved "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.1.tgz"
   integrity sha512-wb2ToxG8LkgPYnKe9FH8oGn3TMCBdnwiuNC5l5y+CtlaVRbCytU0kbVsk6CGrqTL4ZN4ksJa0TXOYbxpbthtqw==
 
 "@chevrotain/utils@11.1.1":
   version "11.1.1"
-  resolved "https://registry.yarnpkg.com/@chevrotain/utils/-/utils-11.1.1.tgz#ba7608d5d3e358127dc0a89e2be24d131d36f750"
+  resolved "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.1.tgz"
   integrity sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ==
 
 "@ctrl/tinycolor@^4.0.4":
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz#ba5d0b917303c0b3d3c14c4865cdc6ded25ac05f"
+  resolved "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz"
   integrity sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==
-
-"@emnapi/runtime@^1.2.0", "@emnapi/runtime@^1.7.0":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.8.1.tgz#550fa7e3c0d49c5fb175a116e8cd70614f9a22a5"
-  integrity sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==
-  dependencies:
-    tslib "^2.4.0"
-
-"@esbuild/aix-ppc64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz#80fcbe36130e58b7670511e888b8e88a259ed76c"
-  integrity sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==
-
-"@esbuild/aix-ppc64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz#815b39267f9bffd3407ea6c376ac32946e24f8d2"
-  integrity sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==
-
-"@esbuild/android-arm64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz#8aa4965f8d0a7982dc21734bf6601323a66da752"
-  integrity sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==
-
-"@esbuild/android-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz#19b882408829ad8e12b10aff2840711b2da361e8"
-  integrity sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==
-
-"@esbuild/android-arm@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.12.tgz#300712101f7f50f1d2627a162e6e09b109b6767a"
-  integrity sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==
-
-"@esbuild/android-arm@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.3.tgz#90be58de27915efa27b767fcbdb37a4470627d7b"
-  integrity sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==
-
-"@esbuild/android-x64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.12.tgz#87dfb27161202bdc958ef48bb61b09c758faee16"
-  integrity sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==
-
-"@esbuild/android-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.3.tgz#d7dcc976f16e01a9aaa2f9b938fbec7389f895ac"
-  integrity sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==
-
-"@esbuild/darwin-arm64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz#79197898ec1ff745d21c071e1c7cc3c802f0c1fd"
-  integrity sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==
-
-"@esbuild/darwin-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz#9f6cac72b3a8532298a6a4493ed639a8988e8abd"
-  integrity sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==
-
-"@esbuild/darwin-x64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz#146400a8562133f45c4d2eadcf37ddd09718079e"
-  integrity sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==
-
-"@esbuild/darwin-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz#ac61d645faa37fd650340f1866b0812e1fb14d6a"
-  integrity sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==
-
-"@esbuild/freebsd-arm64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz#1c5f9ba7206e158fd2b24c59fa2d2c8bb47ca0fe"
-  integrity sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==
-
-"@esbuild/freebsd-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz#b8625689d73cf1830fe58c39051acdc12474ea1b"
-  integrity sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==
-
-"@esbuild/freebsd-x64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz#ea631f4a36beaac4b9279fa0fcc6ca29eaeeb2b3"
-  integrity sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==
-
-"@esbuild/freebsd-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz#07be7dd3c9d42fe0eccd2ab9f9ded780bc53bead"
-  integrity sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==
-
-"@esbuild/linux-arm64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz#e1066bce58394f1b1141deec8557a5f0a22f5977"
-  integrity sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==
-
-"@esbuild/linux-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz#bf31918fe5c798586460d2b3d6c46ed2c01ca0b6"
-  integrity sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==
-
-"@esbuild/linux-arm@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz#452cd66b20932d08bdc53a8b61c0e30baf4348b9"
-  integrity sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==
-
-"@esbuild/linux-arm@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz#28493ee46abec1dc3f500223cd9f8d2df08f9d11"
-  integrity sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==
-
-"@esbuild/linux-ia32@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz#b24f8acc45bcf54192c7f2f3be1b53e6551eafe0"
-  integrity sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==
-
-"@esbuild/linux-ia32@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz#750752a8b30b43647402561eea764d0a41d0ee29"
-  integrity sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==
-
-"@esbuild/linux-loong64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz#f9cfffa7fc8322571fbc4c8b3268caf15bd81ad0"
-  integrity sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==
-
-"@esbuild/linux-loong64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz#a5a92813a04e71198c50f05adfaf18fc1e95b9ed"
-  integrity sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==
-
-"@esbuild/linux-mips64el@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz#575a14bd74644ffab891adc7d7e60d275296f2cd"
-  integrity sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==
-
-"@esbuild/linux-mips64el@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz#deb45d7fd2d2161eadf1fbc593637ed766d50bb1"
-  integrity sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==
-
-"@esbuild/linux-ppc64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz#75b99c70a95fbd5f7739d7692befe60601591869"
-  integrity sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==
-
-"@esbuild/linux-ppc64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz#6f39ae0b8c4d3d2d61a65b26df79f6e12a1c3d78"
-  integrity sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==
-
-"@esbuild/linux-riscv64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz#2e3259440321a44e79ddf7535c325057da875cd6"
-  integrity sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==
-
-"@esbuild/linux-riscv64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz#4c5c19c3916612ec8e3915187030b9df0b955c1d"
-  integrity sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==
-
-"@esbuild/linux-s390x@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz#17676cabbfe5928da5b2a0d6df5d58cd08db2663"
-  integrity sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==
-
-"@esbuild/linux-s390x@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz#9ed17b3198fa08ad5ccaa9e74f6c0aff7ad0156d"
-  integrity sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==
 
 "@esbuild/linux-x64@0.25.12":
   version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz#0583775685ca82066d04c3507f09524d3cd7a306"
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz"
   integrity sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==
 
 "@esbuild/linux-x64@0.27.3":
   version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz#12383dcbf71b7cf6513e58b4b08d95a710bf52a5"
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz"
   integrity sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==
-
-"@esbuild/netbsd-arm64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz#f04c4049cb2e252fe96b16fed90f70746b13f4a4"
-  integrity sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==
-
-"@esbuild/netbsd-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz#dd0cb2fa543205fcd931df44f4786bfcce6df7d7"
-  integrity sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==
-
-"@esbuild/netbsd-x64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz#77da0d0a0d826d7c921eea3d40292548b258a076"
-  integrity sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==
-
-"@esbuild/netbsd-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz#028ad1807a8e03e155153b2d025b506c3787354b"
-  integrity sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==
-
-"@esbuild/openbsd-arm64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz#6296f5867aedef28a81b22ab2009c786a952dccd"
-  integrity sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==
-
-"@esbuild/openbsd-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz#e3c16ff3490c9b59b969fffca87f350ffc0e2af5"
-  integrity sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==
-
-"@esbuild/openbsd-x64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz#f8d23303360e27b16cf065b23bbff43c14142679"
-  integrity sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==
-
-"@esbuild/openbsd-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz#c5a4693fcb03d1cbecbf8b422422468dfc0d2a8b"
-  integrity sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==
-
-"@esbuild/openharmony-arm64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz#49e0b768744a3924be0d7fd97dd6ce9b2923d88d"
-  integrity sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==
-
-"@esbuild/openharmony-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz#082082444f12db564a0775a41e1991c0e125055e"
-  integrity sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==
-
-"@esbuild/sunos-x64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz#a6ed7d6778d67e528c81fb165b23f4911b9b13d6"
-  integrity sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==
-
-"@esbuild/sunos-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz#5ab036c53f929e8405c4e96e865a424160a1b537"
-  integrity sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==
-
-"@esbuild/win32-arm64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz#9ac14c378e1b653af17d08e7d3ce34caef587323"
-  integrity sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==
-
-"@esbuild/win32-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz#38de700ef4b960a0045370c171794526e589862e"
-  integrity sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==
-
-"@esbuild/win32-ia32@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz#918942dcbbb35cc14fca39afb91b5e6a3d127267"
-  integrity sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==
-
-"@esbuild/win32-ia32@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz#451b93dc03ec5d4f38619e6cd64d9f9eff06f55c"
-  integrity sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==
-
-"@esbuild/win32-x64@0.25.12":
-  version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz#9bdad8176be7811ad148d1f8772359041f46c6c5"
-  integrity sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==
-
-"@esbuild/win32-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz#0eaf705c941a218a43dba8e09f1df1d6cd2f1f17"
-  integrity sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==
 
 "@expressive-code/core@^0.40.2":
   version "0.40.2"
-  resolved "https://registry.yarnpkg.com/@expressive-code/core/-/core-0.40.2.tgz#4bf2ffd3879e7adc6177bf240182d153b68b5c6d"
+  resolved "https://registry.npmjs.org/@expressive-code/core/-/core-0.40.2.tgz"
   integrity sha512-gXY3v7jbgz6nWKvRpoDxK4AHUPkZRuJsM79vHX/5uhV9/qX6Qnctp/U/dMHog/LCVXcuOps+5nRmf1uxQVPb3w==
   dependencies:
     "@ctrl/tinycolor" "^4.0.4"
@@ -489,14 +232,14 @@
 
 "@expressive-code/plugin-frames@^0.40.2":
   version "0.40.2"
-  resolved "https://registry.yarnpkg.com/@expressive-code/plugin-frames/-/plugin-frames-0.40.2.tgz#8df2936519de7fde4d70e221b72199fdf038887c"
+  resolved "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.40.2.tgz"
   integrity sha512-aLw5IlDlZWb10Jo/TTDCVsmJhKfZ7FJI83Zo9VDrV0OBlmHAg7klZqw68VDz7FlftIBVAmMby53/MNXPnMjTSQ==
   dependencies:
     "@expressive-code/core" "^0.40.2"
 
 "@expressive-code/plugin-shiki@^0.40.2":
   version "0.40.2"
-  resolved "https://registry.yarnpkg.com/@expressive-code/plugin-shiki/-/plugin-shiki-0.40.2.tgz#afeff8b98b24cf3b79ec1839825b804fc825bd44"
+  resolved "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.40.2.tgz"
   integrity sha512-t2HMR5BO6GdDW1c1ISBTk66xO503e/Z8ecZdNcr6E4NpUfvY+MRje+LtrcvbBqMwWBBO8RpVKcam/Uy+1GxwKQ==
   dependencies:
     "@expressive-code/core" "^0.40.2"
@@ -504,19 +247,19 @@
 
 "@expressive-code/plugin-text-markers@^0.40.2":
   version "0.40.2"
-  resolved "https://registry.yarnpkg.com/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.40.2.tgz#62b9f267634f5574306985b0d73f41da4a3b8395"
+  resolved "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.40.2.tgz"
   integrity sha512-/XoLjD67K9nfM4TgDlXAExzMJp6ewFKxNpfUw4F7q5Ecy+IU3/9zQQG/O70Zy+RxYTwKGw2MA9kd7yelsxnSmw==
   dependencies:
     "@expressive-code/core" "^0.40.2"
 
 "@iconify/types@^2.0.0":
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
+  resolved "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz"
   integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
 
 "@iconify/utils@^3.0.1":
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@iconify/utils/-/utils-3.1.0.tgz#fb41882915f97fee6f91a2fbb8263e8772ca0438"
+  resolved "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz"
   integrity sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==
   dependencies:
     "@antfu/install-pkg" "^1.1.0"
@@ -525,272 +268,65 @@
 
 "@img/colour@^1.0.0":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.0.0.tgz#d2fabb223455a793bf3bf9c70de3d28526aa8311"
+  resolved "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz"
   integrity sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==
-
-"@img/sharp-darwin-arm64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz#ef5b5a07862805f1e8145a377c8ba6e98813ca08"
-  integrity sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-arm64" "1.0.4"
-
-"@img/sharp-darwin-arm64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz#6e0732dcade126b6670af7aa17060b926835ea86"
-  integrity sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-arm64" "1.2.4"
-
-"@img/sharp-darwin-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz#e03d3451cd9e664faa72948cc70a403ea4063d61"
-  integrity sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-x64" "1.0.4"
-
-"@img/sharp-darwin-x64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz#19bc1dd6eba6d5a96283498b9c9f401180ee9c7b"
-  integrity sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-x64" "1.2.4"
-
-"@img/sharp-libvips-darwin-arm64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz#447c5026700c01a993c7804eb8af5f6e9868c07f"
-  integrity sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==
-
-"@img/sharp-libvips-darwin-arm64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz#2894c0cb87d42276c3889942e8e2db517a492c43"
-  integrity sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==
-
-"@img/sharp-libvips-darwin-x64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz#e0456f8f7c623f9dbfbdc77383caa72281d86062"
-  integrity sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==
-
-"@img/sharp-libvips-darwin-x64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz#e63681f4539a94af9cd17246ed8881734386f8cc"
-  integrity sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==
-
-"@img/sharp-libvips-linux-arm64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz#979b1c66c9a91f7ff2893556ef267f90ebe51704"
-  integrity sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==
-
-"@img/sharp-libvips-linux-arm64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz#b1b288b36864b3bce545ad91fa6dadcf1a4ad318"
-  integrity sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==
-
-"@img/sharp-libvips-linux-arm@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz#99f922d4e15216ec205dcb6891b721bfd2884197"
-  integrity sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==
-
-"@img/sharp-libvips-linux-arm@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz#b9260dd1ebe6f9e3bdbcbdcac9d2ac125f35852d"
-  integrity sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==
-
-"@img/sharp-libvips-linux-ppc64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz#4b83ecf2a829057222b38848c7b022e7b4d07aa7"
-  integrity sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==
-
-"@img/sharp-libvips-linux-riscv64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz#880b4678009e5a2080af192332b00b0aaf8a48de"
-  integrity sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==
-
-"@img/sharp-libvips-linux-s390x@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz#f8a5eb1f374a082f72b3f45e2fb25b8118a8a5ce"
-  integrity sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==
-
-"@img/sharp-libvips-linux-s390x@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz#74f343c8e10fad821b38f75ced30488939dc59ec"
-  integrity sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==
 
 "@img/sharp-libvips-linux-x64@1.0.4":
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz#d4c4619cdd157774906e15770ee119931c7ef5e0"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz"
   integrity sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==
 
 "@img/sharp-libvips-linux-x64@1.2.4":
   version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz#df4183e8bd8410f7d61b66859a35edeab0a531ce"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz"
   integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
-
-"@img/sharp-libvips-linuxmusl-arm64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz#166778da0f48dd2bded1fa3033cee6b588f0d5d5"
-  integrity sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==
-
-"@img/sharp-libvips-linuxmusl-arm64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz#c8d6b48211df67137541007ee8d1b7b1f8ca8e06"
-  integrity sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==
 
 "@img/sharp-libvips-linuxmusl-x64@1.0.4":
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz#93794e4d7720b077fcad3e02982f2f1c246751ff"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz"
   integrity sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==
 
 "@img/sharp-libvips-linuxmusl-x64@1.2.4":
   version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz#be11c75bee5b080cbee31a153a8779448f919f75"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz"
   integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
-
-"@img/sharp-linux-arm64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz#edb0697e7a8279c9fc829a60fc35644c4839bb22"
-  integrity sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm64" "1.0.4"
-
-"@img/sharp-linux-arm64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz#7aa7764ef9c001f15e610546d42fce56911790cc"
-  integrity sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm64" "1.2.4"
-
-"@img/sharp-linux-arm@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz#422c1a352e7b5832842577dc51602bcd5b6f5eff"
-  integrity sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm" "1.0.5"
-
-"@img/sharp-linux-arm@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz#5fb0c3695dd12522d39c3ff7a6bc816461780a0d"
-  integrity sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm" "1.2.4"
-
-"@img/sharp-linux-ppc64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz#9c213a81520a20caf66978f3d4c07456ff2e0813"
-  integrity sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-ppc64" "1.2.4"
-
-"@img/sharp-linux-riscv64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz#cdd28182774eadbe04f62675a16aabbccb833f60"
-  integrity sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-riscv64" "1.2.4"
-
-"@img/sharp-linux-s390x@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz#f5c077926b48e97e4a04d004dfaf175972059667"
-  integrity sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-s390x" "1.0.4"
-
-"@img/sharp-linux-s390x@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz#93eac601b9f329bb27917e0e19098c722d630df7"
-  integrity sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-s390x" "1.2.4"
 
 "@img/sharp-linux-x64@0.33.5":
   version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz#d806e0afd71ae6775cc87f0da8f2d03a7c2209cb"
+  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz"
   integrity sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==
   optionalDependencies:
     "@img/sharp-libvips-linux-x64" "1.0.4"
 
 "@img/sharp-linux-x64@0.34.5":
   version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz#55abc7cd754ffca5002b6c2b719abdfc846819a8"
+  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz"
   integrity sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==
   optionalDependencies:
     "@img/sharp-libvips-linux-x64" "1.2.4"
 
-"@img/sharp-linuxmusl-arm64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz#252975b915894fb315af5deea174651e208d3d6b"
-  integrity sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==
-  optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-arm64" "1.0.4"
-
-"@img/sharp-linuxmusl-arm64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz#d6515ee971bb62f73001a4829b9d865a11b77086"
-  integrity sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==
-  optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-arm64" "1.2.4"
-
 "@img/sharp-linuxmusl-x64@0.33.5":
   version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz#3f4609ac5d8ef8ec7dadee80b560961a60fd4f48"
+  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz"
   integrity sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==
   optionalDependencies:
     "@img/sharp-libvips-linuxmusl-x64" "1.0.4"
 
 "@img/sharp-linuxmusl-x64@0.34.5":
   version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz#d97978aec7c5212f999714f2f5b736457e12ee9f"
+  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz"
   integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
   optionalDependencies:
     "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
 
-"@img/sharp-wasm32@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz#6f44f3283069d935bb5ca5813153572f3e6f61a1"
-  integrity sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==
-  dependencies:
-    "@emnapi/runtime" "^1.2.0"
-
-"@img/sharp-wasm32@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz#2f15803aa626f8c59dd7c9d0bbc766f1ab52cfa0"
-  integrity sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==
-  dependencies:
-    "@emnapi/runtime" "^1.7.0"
-
-"@img/sharp-win32-arm64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz#3706e9e3ac35fddfc1c87f94e849f1b75307ce0a"
-  integrity sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==
-
-"@img/sharp-win32-ia32@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz#1a0c839a40c5351e9885628c85f2e5dfd02b52a9"
-  integrity sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==
-
-"@img/sharp-win32-ia32@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz#0b71166599b049e032f085fb9263e02f4e4788de"
-  integrity sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==
-
-"@img/sharp-win32-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz#56f00962ff0c4e0eb93d34a047d29fa995e3e342"
-  integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
-
-"@img/sharp-win32-x64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz#a81ffb00e69267cd0a1d626eaedb8a8430b2b2f8"
-  integrity sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==
-
 "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
 "@mdx-js/mdx@^3.1.1":
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-3.1.1.tgz#c5ffd991a7536b149e17175eee57a1a2a511c6d1"
+  resolved "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz"
   integrity sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -821,188 +357,48 @@
 
 "@mermaid-js/parser@^1.0.0":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@mermaid-js/parser/-/parser-1.0.0.tgz#076d01775f841d7578cdc6b68a428c749120e6b3"
+  resolved "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.0.tgz"
   integrity sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==
   dependencies:
     langium "^4.0.0"
 
 "@oslojs/encoding@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@oslojs/encoding/-/encoding-1.1.0.tgz#55f3d9a597430a01f2a5ef63c6b42f769f9ce34e"
+  resolved "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz"
   integrity sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==
-
-"@pagefind/darwin-arm64@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz#0315030e6a89bec3121273b1851f7aadf0b12425"
-  integrity sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==
-
-"@pagefind/darwin-x64@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz#671e1fe0f0733350a3eb244ace2675166186793e"
-  integrity sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==
 
 "@pagefind/default-ui@^1.3.0":
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@pagefind/default-ui/-/default-ui-1.4.0.tgz#036017ba6ed40e9f34ff5652b9caed11113f7bcc"
+  resolved "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.4.0.tgz"
   integrity sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ==
-
-"@pagefind/freebsd-x64@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz#3419701ce810e7ec050bbf4786b1c3bee78ec51b"
-  integrity sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==
-
-"@pagefind/linux-arm64@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz#ba2a5c8d10d5273fe61a8d230b546b08d22cb676"
-  integrity sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==
 
 "@pagefind/linux-x64@1.4.0":
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz#1e56bb3c91fd0128be84e98897c9785c489fbbb7"
+  resolved "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz"
   integrity sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==
-
-"@pagefind/windows-x64@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz#ba68fd609621132e8e314a89e2d2d52516f61723"
-  integrity sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==
 
 "@rollup/pluginutils@^5.3.0":
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.3.0.tgz#57ba1b0cbda8e7a3c597a4853c807b156e21a7b4"
+  resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz"
   integrity sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==
   dependencies:
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-android-arm-eabi@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz#a6742c74c7d9d6d604ef8a48f99326b4ecda3d82"
-  integrity sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==
+"@rollup/rollup-linux-x64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz"
+  integrity sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==
 
-"@rollup/rollup-android-arm64@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz#97247be098de4df0c11971089fd2edf80a5da8cf"
-  integrity sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==
-
-"@rollup/rollup-darwin-arm64@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz#674852cf14cf11b8056e0b1a2f4e872b523576cf"
-  integrity sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==
-
-"@rollup/rollup-darwin-x64@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz#36dfd7ed0aaf4d9d89d9ef983af72632455b0246"
-  integrity sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==
-
-"@rollup/rollup-freebsd-arm64@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz#2f87c2074b4220260fdb52a9996246edfc633c22"
-  integrity sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==
-
-"@rollup/rollup-freebsd-x64@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz#9b5a26522a38a95dc06616d1939d4d9a76937803"
-  integrity sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz#86aa4859385a8734235b5e40a48e52d770758c3a"
-  integrity sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==
-
-"@rollup/rollup-linux-arm-musleabihf@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz#cbe70e56e6ece8dac83eb773b624fc9e5a460976"
-  integrity sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==
-
-"@rollup/rollup-linux-arm64-gnu@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz#d14992a2e653bc3263d284bc6579b7a2890e1c45"
-  integrity sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==
-
-"@rollup/rollup-linux-arm64-musl@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz#2fdd1ddc434ea90aeaa0851d2044789b4d07f6da"
-  integrity sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==
-
-"@rollup/rollup-linux-loong64-gnu@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz#8a181e6f89f969f21666a743cd411416c80099e7"
-  integrity sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==
-
-"@rollup/rollup-linux-loong64-musl@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz#904125af2babc395f8061daa27b5af1f4e3f2f78"
-  integrity sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==
-
-"@rollup/rollup-linux-ppc64-gnu@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz#a57970ac6864c9a3447411a658224bdcf948be22"
-  integrity sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==
-
-"@rollup/rollup-linux-ppc64-musl@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz#bb84de5b26870567a4267666e08891e80bb56a63"
-  integrity sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==
-
-"@rollup/rollup-linux-riscv64-gnu@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz#72d00d2c7fb375ce3564e759db33f17a35bffab9"
-  integrity sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==
-
-"@rollup/rollup-linux-riscv64-musl@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz#4c166ef58e718f9245bd31873384ba15a5c1a883"
-  integrity sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==
-
-"@rollup/rollup-linux-s390x-gnu@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz#bb5025cde9a61db478c2ca7215808ad3bce73a09"
-  integrity sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==
-
-"@rollup/rollup-linux-x64-gnu@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz#9b66b1f9cd95c6624c788f021c756269ffed1552"
-  integrity sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==
-
-"@rollup/rollup-linux-x64-musl@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz#b007ca255dc7166017d57d7d2451963f0bd23fd9"
-  integrity sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==
-
-"@rollup/rollup-openbsd-x64@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz#e8b357b2d1aa2c8d76a98f5f0d889eabe93f4ef9"
-  integrity sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==
-
-"@rollup/rollup-openharmony-arm64@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz#96c2e3f4aacd3d921981329831ff8dde492204dc"
-  integrity sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==
-
-"@rollup/rollup-win32-arm64-msvc@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz#2d865149d706d938df8b4b8f117e69a77646d581"
-  integrity sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==
-
-"@rollup/rollup-win32-ia32-msvc@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz#abe1593be0fa92325e9971c8da429c5e05b92c36"
-  integrity sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==
-
-"@rollup/rollup-win32-x64-gnu@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz#c4af3e9518c9a5cd4b1c163dc81d0ad4d82e7eab"
-  integrity sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==
-
-"@rollup/rollup-win32-x64-msvc@4.59.0":
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz#4584a8a87b29188a4c1fe987a9fcf701e256d86c"
-  integrity sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==
+"@rollup/rollup-linux-x64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz"
+  integrity sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==
 
 "@shikijs/core@1.29.2":
   version "1.29.2"
-  resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-1.29.2.tgz#9c051d3ac99dd06ae46bd96536380c916e552bf3"
+  resolved "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz"
   integrity sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==
   dependencies:
     "@shikijs/engine-javascript" "1.29.2"
@@ -1014,7 +410,7 @@
 
 "@shikijs/core@3.22.0":
   version "3.22.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-3.22.0.tgz#9e9e8bd6d65b61fa74205a30491b921079996cdd"
+  resolved "https://registry.npmjs.org/@shikijs/core/-/core-3.22.0.tgz"
   integrity sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==
   dependencies:
     "@shikijs/types" "3.22.0"
@@ -1024,7 +420,7 @@
 
 "@shikijs/engine-javascript@1.29.2":
   version "1.29.2"
-  resolved "https://registry.yarnpkg.com/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz#a821ad713a3e0b7798a1926fd9e80116e38a1d64"
+  resolved "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz"
   integrity sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==
   dependencies:
     "@shikijs/types" "1.29.2"
@@ -1033,7 +429,7 @@
 
 "@shikijs/engine-javascript@3.22.0":
   version "3.22.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/engine-javascript/-/engine-javascript-3.22.0.tgz#507f5cbb3e565268a35ee8aed42ff73016899e6d"
+  resolved "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.22.0.tgz"
   integrity sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==
   dependencies:
     "@shikijs/types" "3.22.0"
@@ -1042,7 +438,7 @@
 
 "@shikijs/engine-oniguruma@1.29.2":
   version "1.29.2"
-  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz#d879717ced61d44e78feab16f701f6edd75434f1"
+  resolved "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz"
   integrity sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==
   dependencies:
     "@shikijs/types" "1.29.2"
@@ -1050,7 +446,7 @@
 
 "@shikijs/engine-oniguruma@3.22.0":
   version "3.22.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-3.22.0.tgz#d16b66ed18470bc99f5026ec9f635695a10cb7f5"
+  resolved "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.22.0.tgz"
   integrity sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==
   dependencies:
     "@shikijs/types" "3.22.0"
@@ -1058,35 +454,35 @@
 
 "@shikijs/langs@1.29.2":
   version "1.29.2"
-  resolved "https://registry.yarnpkg.com/@shikijs/langs/-/langs-1.29.2.tgz#4f1de46fde8991468c5a68fa4a67dd2875d643cd"
+  resolved "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz"
   integrity sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==
   dependencies:
     "@shikijs/types" "1.29.2"
 
 "@shikijs/langs@3.22.0":
   version "3.22.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/langs/-/langs-3.22.0.tgz#949338647714b89314efbd333070b0c0263b232a"
+  resolved "https://registry.npmjs.org/@shikijs/langs/-/langs-3.22.0.tgz"
   integrity sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==
   dependencies:
     "@shikijs/types" "3.22.0"
 
 "@shikijs/themes@1.29.2":
   version "1.29.2"
-  resolved "https://registry.yarnpkg.com/@shikijs/themes/-/themes-1.29.2.tgz#293cc5c83dd7df3fdc8efa25cec8223f3a6acb0d"
+  resolved "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz"
   integrity sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==
   dependencies:
     "@shikijs/types" "1.29.2"
 
 "@shikijs/themes@3.22.0":
   version "3.22.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/themes/-/themes-3.22.0.tgz#0a316f0b1bda2dea378dd0c9d7e0a703f36af2c3"
+  resolved "https://registry.npmjs.org/@shikijs/themes/-/themes-3.22.0.tgz"
   integrity sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==
   dependencies:
     "@shikijs/types" "3.22.0"
 
 "@shikijs/types@1.29.2":
   version "1.29.2"
-  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-1.29.2.tgz#a93fdb410d1af8360c67bf5fc1d1a68d58e21c4f"
+  resolved "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz"
   integrity sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==
   dependencies:
     "@shikijs/vscode-textmate" "^10.0.1"
@@ -1094,7 +490,7 @@
 
 "@shikijs/types@3.22.0":
   version "3.22.0"
-  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-3.22.0.tgz#43fe92d163742424e794894cb27ce6ce1b4ca8a8"
+  resolved "https://registry.npmjs.org/@shikijs/types/-/types-3.22.0.tgz"
   integrity sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==
   dependencies:
     "@shikijs/vscode-textmate" "^10.0.2"
@@ -1102,41 +498,41 @@
 
 "@shikijs/vscode-textmate@^10.0.1", "@shikijs/vscode-textmate@^10.0.2":
   version "10.0.2"
-  resolved "https://registry.yarnpkg.com/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz#a90ab31d0cc1dfb54c66a69e515bf624fa7b2224"
+  resolved "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz"
   integrity sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
 
 "@types/d3-array@*":
   version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.2.tgz#e02151464d02d4a1b44646d0fcdb93faf88fde8c"
+  resolved "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz"
   integrity sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
 
 "@types/d3-axis@*":
   version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-3.0.6.tgz#e760e5765b8188b1defa32bc8bb6062f81e4c795"
+  resolved "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz"
   integrity sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==
   dependencies:
     "@types/d3-selection" "*"
 
 "@types/d3-brush@*":
   version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@types/d3-brush/-/d3-brush-3.0.6.tgz#c2f4362b045d472e1b186cdbec329ba52bdaee6c"
+  resolved "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz"
   integrity sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==
   dependencies:
     "@types/d3-selection" "*"
 
 "@types/d3-chord@*":
   version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-3.0.6.tgz#1706ca40cf7ea59a0add8f4456efff8f8775793d"
+  resolved "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz"
   integrity sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==
 
 "@types/d3-color@*":
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  resolved "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz"
   integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
 
 "@types/d3-contour@*":
   version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@types/d3-contour/-/d3-contour-3.0.6.tgz#9ada3fa9c4d00e3a5093fed0356c7ab929604231"
+  resolved "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz"
   integrity sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==
   dependencies:
     "@types/d3-array" "*"
@@ -1144,136 +540,136 @@
 
 "@types/d3-delaunay@*":
   version "6.0.4"
-  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
+  resolved "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz"
   integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
 
 "@types/d3-dispatch@*":
   version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz#ef004d8a128046cfce434d17182f834e44ef95b2"
+  resolved "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz"
   integrity sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
 
 "@types/d3-drag@*":
   version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.7.tgz#b13aba8b2442b4068c9a9e6d1d82f8bcea77fc02"
+  resolved "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz"
   integrity sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==
   dependencies:
     "@types/d3-selection" "*"
 
 "@types/d3-dsv@*":
   version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz#0a351f996dc99b37f4fa58b492c2d1c04e3dac17"
+  resolved "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz"
   integrity sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==
 
 "@types/d3-ease@*":
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  resolved "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz"
   integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
 
 "@types/d3-fetch@*":
   version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz#c04a2b4f23181aa376f30af0283dbc7b3b569980"
+  resolved "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz"
   integrity sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==
   dependencies:
     "@types/d3-dsv" "*"
 
 "@types/d3-force@*":
   version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-3.0.10.tgz#6dc8fc6e1f35704f3b057090beeeb7ac674bff1a"
+  resolved "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz"
   integrity sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==
 
 "@types/d3-format@*":
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.4.tgz#b1e4465644ddb3fdf3a263febb240a6cd616de90"
+  resolved "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz"
   integrity sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==
 
 "@types/d3-geo@*":
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-3.1.0.tgz#b9e56a079449174f0a2c8684a9a4df3f60522440"
+  resolved "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz"
   integrity sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==
   dependencies:
     "@types/geojson" "*"
 
 "@types/d3-hierarchy@*":
   version "3.1.7"
-  resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz#6023fb3b2d463229f2d680f9ac4b47466f71f17b"
+  resolved "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz"
   integrity sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==
 
 "@types/d3-interpolate@*":
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  resolved "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz"
   integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
   dependencies:
     "@types/d3-color" "*"
 
 "@types/d3-path@*":
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
+  resolved "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz"
   integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
 
 "@types/d3-polygon@*":
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz#dfae54a6d35d19e76ac9565bcb32a8e54693189c"
+  resolved "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz"
   integrity sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==
 
 "@types/d3-quadtree@*":
   version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz#d4740b0fe35b1c58b66e1488f4e7ed02952f570f"
+  resolved "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz"
   integrity sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==
 
 "@types/d3-random@*":
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-3.0.3.tgz#ed995c71ecb15e0cd31e22d9d5d23942e3300cfb"
+  resolved "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz"
   integrity sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==
 
 "@types/d3-scale-chromatic@*":
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#dc6d4f9a98376f18ea50bad6c39537f1b5463c39"
+  resolved "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz"
   integrity sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==
 
 "@types/d3-scale@*":
   version "4.0.9"
-  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  resolved "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz"
   integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
   dependencies:
     "@types/d3-time" "*"
 
 "@types/d3-selection@*":
   version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.11.tgz#bd7a45fc0a8c3167a631675e61bc2ca2b058d4a3"
+  resolved "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz"
   integrity sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==
 
 "@types/d3-shape@*":
   version "3.1.8"
-  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.8.tgz#d1516cc508753be06852cd06758e3bb54a22b0e3"
+  resolved "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz"
   integrity sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==
   dependencies:
     "@types/d3-path" "*"
 
 "@types/d3-time-format@*":
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz#d6bc1e6b6a7db69cccfbbdd4c34b70632d9e9db2"
+  resolved "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz"
   integrity sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==
 
 "@types/d3-time@*":
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  resolved "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz"
   integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
 
 "@types/d3-timer@*":
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  resolved "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz"
   integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
 
 "@types/d3-transition@*":
   version "3.0.9"
-  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-3.0.9.tgz#1136bc57e9ddb3c390dccc9b5ff3b7d2b8d94706"
+  resolved "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz"
   integrity sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==
   dependencies:
     "@types/d3-selection" "*"
 
 "@types/d3-zoom@*":
   version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz#dccb32d1c56b1e1c6e0f1180d994896f038bc40b"
+  resolved "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz"
   integrity sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==
   dependencies:
     "@types/d3-interpolate" "*"
@@ -1281,7 +677,7 @@
 
 "@types/d3@^7.4.3":
   version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-7.4.3.tgz#d4550a85d08f4978faf0a4c36b848c61eaac07e2"
+  resolved "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz"
   integrity sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==
   dependencies:
     "@types/d3-array" "*"
@@ -1317,138 +713,138 @@
 
 "@types/debug@^4.0.0":
   version "4.1.12"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
+  resolved "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz"
   integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
   dependencies:
     "@types/ms" "*"
 
 "@types/estree-jsx@^1.0.0":
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-1.0.5.tgz#858a88ea20f34fe65111f005a689fa1ebf70dc18"
+  resolved "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz"
   integrity sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==
   dependencies:
     "@types/estree" "*"
 
-"@types/estree@*", "@types/estree@1.0.8", "@types/estree@^1.0.0":
+"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@1.0.8":
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
 "@types/geojson@*":
   version "7946.0.16"
-  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  resolved "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz"
   integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
 
 "@types/hast@^3.0.0", "@types/hast@^3.0.4":
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"
+  resolved "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz"
   integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
   dependencies:
     "@types/unist" "*"
 
 "@types/js-yaml@^4.0.9":
   version "4.0.9"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  resolved "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz"
   integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
 
 "@types/mdast@^4.0.0", "@types/mdast@^4.0.4":
   version "4.0.4"
-  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-4.0.4.tgz#7ccf72edd2f1aa7dd3437e180c64373585804dd6"
+  resolved "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz"
   integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
   dependencies:
     "@types/unist" "*"
 
 "@types/mdx@^2.0.0":
   version "2.0.13"
-  resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.13.tgz#68f6877043d377092890ff5b298152b0a21671bd"
+  resolved "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz"
   integrity sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==
 
 "@types/ms@*":
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  resolved "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
 "@types/nlcst@^2.0.0":
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/nlcst/-/nlcst-2.0.3.tgz#31cad346eaab48a9a8a58465d3d05e2530dda762"
+  resolved "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz"
   integrity sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==
   dependencies:
     "@types/unist" "*"
 
-"@types/node@*":
-  version "25.3.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.3.0.tgz#749b1bd4058e51b72e22bd41e9eab6ebd0180470"
-  integrity sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==
+"@types/node@*", "@types/node@^18.0.0 || ^20.0.0 || >=22.0.0":
+  version "25.2.3"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz"
+  integrity sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==
   dependencies:
-    undici-types "~7.18.0"
+    undici-types "~7.16.0"
 
 "@types/node@^17.0.5":
   version "17.0.45"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
+  resolved "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
 "@types/sax@^1.2.1":
   version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.7.tgz#ba5fe7df9aa9c89b6dff7688a19023dd2963091d"
+  resolved "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz"
   integrity sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==
   dependencies:
     "@types/node" "*"
 
 "@types/trusted-types@^2.0.7":
   version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  resolved "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
+  resolved "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
 "@types/unist@^2.0.0":
   version "2.0.11"
-  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
+  resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz"
   integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
 
 "@ungap/structured-clone@^1.0.0":
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
+  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
 acorn-jsx@^5.0.0:
   version "5.3.2"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.0.0, acorn@^8.15.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
-  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.0.0, acorn@^8.15.0:
+  version "8.15.0"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
+  integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
 ansi-align@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.1.tgz#0cdf12e111ace773a86e9a1fad1225c43cb19a59"
+  resolved "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz"
   integrity sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==
   dependencies:
     string-width "^4.1.0"
 
 ansi-regex@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-regex@^6.0.1:
   version "6.2.2"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
   integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
 
 ansi-styles@^6.2.1:
   version "6.2.3"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 anymatch@^3.1.3:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
   dependencies:
     normalize-path "^3.0.0"
@@ -1456,49 +852,49 @@ anymatch@^3.1.3:
 
 arg@^5.0.0:
   version "5.0.2"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  resolved "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz"
   integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
 argparse@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 aria-query@^5.3.2:
   version "5.3.2"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
+  resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
 
 array-iterate@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-2.0.1.tgz#6efd43f8295b3fee06251d3d62ead4bd9805dd24"
+  resolved "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz"
   integrity sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==
 
 astring@^1.8.0:
   version "1.9.0"
-  resolved "https://registry.yarnpkg.com/astring/-/astring-1.9.0.tgz#cc73e6062a7eb03e7d19c22d8b0b3451fd9bfeef"
+  resolved "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz"
   integrity sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==
 
 astro-expressive-code@^0.40.0:
   version "0.40.2"
-  resolved "https://registry.yarnpkg.com/astro-expressive-code/-/astro-expressive-code-0.40.2.tgz#caee511b873c5c93f22cbca469dcd6f7ad3d86ee"
+  resolved "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.40.2.tgz"
   integrity sha512-yJMQId0yXSAbW9I6yqvJ3FcjKzJ8zRL7elbJbllkv1ZJPlsI0NI83Pxn1YL1IapEM347EvOOkSW2GL+2+NO61w==
   dependencies:
     rehype-expressive-code "^0.40.2"
 
 astro-mermaid@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/astro-mermaid/-/astro-mermaid-1.3.1.tgz#7d8f4716ec0a26e4f92ea15318f93e4141a3d3a1"
+  resolved "https://registry.npmjs.org/astro-mermaid/-/astro-mermaid-1.3.1.tgz"
   integrity sha512-1+FjwayMSZLtFd+ofdu1+v8a902nN5wmPmjY2qb8tLiO96YlL65LbskiuUcyH6q9h0CdZCrkc5FimlaHZsMJsg==
   dependencies:
     import-meta-resolve "^4.2.0"
     mdast-util-to-string "^4.0.0"
     unist-util-visit "^5.0.0"
 
-astro@^5.3.0:
-  version "5.17.3"
-  resolved "https://registry.yarnpkg.com/astro/-/astro-5.17.3.tgz#dd0d3fd659b280d7ff20fc5fc37277675ebd2e82"
-  integrity sha512-69dcfPe8LsHzklwj+hl+vunWUbpMB6pmg35mACjetxbJeUNNys90JaBM8ZiwsPK689SAj/4Zqb1ayaANls9/MA==
+"astro@^4.0.0 || ^5.0.0", "astro@^4.0.0-beta || ^5.0.0-beta || ^3.3.0", astro@^5.0.0, astro@^5.1.5, astro@^5.3.0:
+  version "5.17.2"
+  resolved "https://registry.npmjs.org/astro/-/astro-5.17.2.tgz"
+  integrity sha512-7jnMqGo53hOQNwo1N/wqeOvUp8wwW/p+DeerSjSkHNx8L/1mhy6P7rVo7EhdmF8DpKqw0tl/B5Fx1WcIzg1ysA==
   dependencies:
     "@astrojs/compiler" "^2.13.0"
     "@astrojs/internal-helpers" "0.7.5"
@@ -1523,7 +919,7 @@ astro@^5.3.0:
     dlv "^1.1.3"
     dset "^3.1.4"
     es-module-lexer "^1.7.0"
-    esbuild "^0.27.3"
+    esbuild "^0.27.0"
     estree-walker "^3.0.3"
     flattie "^1.1.1"
     fontace "~0.4.0"
@@ -1568,27 +964,27 @@ astro@^5.3.0:
 
 axobject-query@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
+  resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
 bail@^2.0.0:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  resolved "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz"
   integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
 
 base-64@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
+  resolved "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz"
   integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
 
 bcp-47-match@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/bcp-47-match/-/bcp-47-match-2.0.3.tgz#603226f6e5d3914a581408be33b28a53144b09d0"
+  resolved "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz"
   integrity sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==
 
 bcp-47@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/bcp-47/-/bcp-47-2.1.0.tgz#7e80734c3338fe8320894981dccf4968c3092df6"
+  resolved "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz"
   integrity sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==
   dependencies:
     is-alphabetical "^2.0.0"
@@ -1597,12 +993,12 @@ bcp-47@^2.1.0:
 
 boolbase@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 boxen@8.0.1:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-8.0.1.tgz#7e9fcbb45e11a2d7e6daa8fdcebfc3242fc19fe3"
+  resolved "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz"
   integrity sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==
   dependencies:
     ansi-align "^3.0.1"
@@ -1616,49 +1012,49 @@ boxen@8.0.1:
 
 camelcase@^8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-8.0.0.tgz#c0d36d418753fb6ad9c5e0437579745c1c14a534"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz"
   integrity sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==
 
 ccount@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
+  resolved "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
 chalk@^5.3.0:
   version "5.6.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
 
 character-entities-html4@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  resolved "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz"
   integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
 
 character-entities-legacy@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  resolved "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz"
   integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
 
 character-entities@^2.0.0:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  resolved "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz"
   integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
 
 character-reference-invalid@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
+  resolved "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz"
   integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
 
 chevrotain-allstar@~0.3.1:
   version "0.3.1"
-  resolved "https://registry.yarnpkg.com/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz#b7412755f5d83cc139ab65810cdb00d8db40e6ca"
+  resolved "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz"
   integrity sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==
   dependencies:
     lodash-es "^4.17.21"
 
-chevrotain@~11.1.1:
+chevrotain@^11.0.0, chevrotain@~11.1.1:
   version "11.1.1"
-  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-11.1.1.tgz#39be6f767cb22cc6a728246995ba906c5c2f2157"
+  resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.1.tgz"
   integrity sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==
   dependencies:
     "@chevrotain/cst-dts-gen" "11.1.1"
@@ -1670,46 +1066,46 @@ chevrotain@~11.1.1:
 
 chokidar@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-5.0.0.tgz#949c126a9238a80792be9a0265934f098af369a5"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz"
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
 
 ci-info@^4.2.0, ci-info@^4.3.1:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
+  resolved "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz"
   integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
 
 cli-boxes@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-3.0.0.tgz#71a10c716feeba005e4504f36329ef0b17cf3145"
+  resolved "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz"
   integrity sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==
 
 clsx@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 collapse-white-space@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-2.1.0.tgz#640257174f9f42c740b40f3b55ee752924feefca"
+  resolved "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz"
   integrity sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==
 
 color-convert@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
 
 color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-string@^1.9.0:
   version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  resolved "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz"
   integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
   dependencies:
     color-name "^1.0.0"
@@ -1717,7 +1113,7 @@ color-string@^1.9.0:
 
 color@^4.2.3:
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  resolved "https://registry.npmjs.org/color/-/color-4.2.3.tgz"
   integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
   dependencies:
     color-convert "^2.0.1"
@@ -1725,68 +1121,68 @@ color@^4.2.3:
 
 comma-separated-tokens@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
+  resolved "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz"
   integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
-
-commander@7:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
-  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^11.1.0:
   version "11.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  resolved "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz"
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@^8.3.0:
   version "8.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  resolved "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 common-ancestor-path@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
+  resolved "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz"
   integrity sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==
 
 confbox@^0.1.8:
   version "0.1.8"
-  resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.8.tgz#820d73d3b3c82d9bd910652c5d4d599ef8ff8b06"
+  resolved "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz"
   integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
 
 cookie-es@^1.2.2:
   version "1.2.2"
-  resolved "https://registry.yarnpkg.com/cookie-es/-/cookie-es-1.2.2.tgz#18ceef9eb513cac1cb6c14bcbf8bdb2679b34821"
+  resolved "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz"
   integrity sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==
 
 cookie@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz"
   integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
 cose-base@^1.0.0:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-1.0.3.tgz#650334b41b869578a543358b80cda7e0abe0a60a"
+  resolved "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz"
   integrity sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
   dependencies:
     layout-base "^1.0.0"
 
 cose-base@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-2.2.0.tgz#1c395c35b6e10bb83f9769ca8b817d614add5c01"
+  resolved "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz"
   integrity sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==
   dependencies:
     layout-base "^2.0.0"
 
 crossws@^0.3.5:
   version "0.3.5"
-  resolved "https://registry.yarnpkg.com/crossws/-/crossws-0.3.5.tgz#daad331d44148ea6500098bc858869f3a5ab81a6"
+  resolved "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz"
   integrity sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==
   dependencies:
     uncrypto "^0.1.3"
 
 css-select@^5.1.0:
   version "5.2.2"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.2.2.tgz#01b6e8d163637bb2dd6c982ca4ed65863682786e"
+  resolved "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz"
   integrity sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==
   dependencies:
     boolbase "^1.0.0"
@@ -1797,12 +1193,12 @@ css-select@^5.1.0:
 
 css-selector-parser@^3.0.0:
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-3.3.0.tgz#1a34220d76762c929ae99993df5a60721f505082"
+  resolved "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz"
   integrity sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==
 
 css-tree@^3.0.1, css-tree@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-3.1.0.tgz#7aabc035f4e66b5c86f54570d55e05b1346eb0fd"
+  resolved "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz"
   integrity sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==
   dependencies:
     mdn-data "2.12.2"
@@ -1810,7 +1206,7 @@ css-tree@^3.0.1, css-tree@^3.1.0:
 
 css-tree@~2.2.0:
   version "2.2.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.2.1.tgz#36115d382d60afd271e377f9c5f67d02bd48c032"
+  resolved "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz"
   integrity sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==
   dependencies:
     mdn-data "2.0.28"
@@ -1818,62 +1214,62 @@ css-tree@~2.2.0:
 
 css-what@^6.1.0:
   version "6.2.2"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
+  resolved "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz"
   integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
 cssesc@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 csso@^5.0.5:
   version "5.0.5"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-5.0.5.tgz#f9b7fe6cc6ac0b7d90781bb16d5e9874303e2ca6"
+  resolved "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz"
   integrity sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==
   dependencies:
     css-tree "~2.2.0"
 
 cytoscape-cose-bilkent@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz#762fa121df9930ffeb51a495d87917c570ac209b"
+  resolved "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz"
   integrity sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==
   dependencies:
     cose-base "^1.0.0"
 
 cytoscape-fcose@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz#e4d6f6490df4fab58ae9cea9e5c3ab8d7472f471"
+  resolved "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz"
   integrity sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==
   dependencies:
     cose-base "^2.2.0"
 
-cytoscape@^3.29.3:
+cytoscape@^3.2.0, cytoscape@^3.29.3:
   version "3.33.1"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.33.1.tgz#449e05d104b760af2912ab76482d24c01cdd4c97"
+  resolved "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz"
   integrity sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==
 
-"d3-array@1 - 2":
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
-  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
-  dependencies:
-    internmap "^1.0.0"
-
-"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+d3-array@^3.2.0, "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3:
   version "3.2.4"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  resolved "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
   dependencies:
     internmap "1 - 2"
 
+"d3-array@1 - 2":
+  version "2.12.1"
+  resolved "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz"
+  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
+  dependencies:
+    internmap "^1.0.0"
+
 d3-axis@3:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  resolved "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz"
   integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
 
 d3-brush@3:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  resolved "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz"
   integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
   dependencies:
     d3-dispatch "1 - 3"
@@ -1884,38 +1280,38 @@ d3-brush@3:
 
 d3-chord@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  resolved "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz"
   integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
   dependencies:
     d3-path "1 - 3"
 
 "d3-color@1 - 3", d3-color@3:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  resolved "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
 d3-contour@4:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
+  resolved "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz"
   integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
   dependencies:
     d3-array "^3.2.0"
 
 d3-delaunay@6:
   version "6.0.4"
-  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  resolved "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz"
   integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
   dependencies:
     delaunator "5"
 
 "d3-dispatch@1 - 3", d3-dispatch@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  resolved "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
 
 "d3-drag@2 - 3", d3-drag@3:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  resolved "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz"
   integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
   dependencies:
     d3-dispatch "1 - 3"
@@ -1923,7 +1319,7 @@ d3-delaunay@6:
 
 "d3-dsv@1 - 3", d3-dsv@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  resolved "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz"
   integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
   dependencies:
     commander "7"
@@ -1932,19 +1328,19 @@ d3-delaunay@6:
 
 "d3-ease@1 - 3", d3-ease@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  resolved "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz"
   integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
 
 d3-fetch@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  resolved "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz"
   integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
   dependencies:
     d3-dsv "1 - 3"
 
 d3-force@3:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  resolved "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz"
   integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
   dependencies:
     d3-dispatch "1 - 3"
@@ -1953,56 +1349,56 @@ d3-force@3:
 
 "d3-format@1 - 3", d3-format@3:
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  resolved "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz"
   integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
 
 d3-geo@3:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.1.tgz#6027cf51246f9b2ebd64f99e01dc7c3364033a4d"
+  resolved "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz"
   integrity sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
   dependencies:
     d3-array "2.5.0 - 3"
 
 d3-hierarchy@3:
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  resolved "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz"
   integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
 
 "d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  resolved "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
   dependencies:
     d3-color "1 - 3"
 
+d3-path@^3.1.0, "d3-path@1 - 3", d3-path@3:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
 d3-path@1:
   version "1.0.9"
-  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  resolved "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz"
   integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
-
-"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
-  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
 
 d3-polygon@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  resolved "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz"
   integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
 
 "d3-quadtree@1 - 3", d3-quadtree@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  resolved "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz"
   integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
 
 d3-random@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  resolved "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz"
   integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
 
 d3-sankey@^0.12.3:
   version "0.12.3"
-  resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.12.3.tgz#b3c268627bd72e5d80336e8de6acbfec9d15d01d"
+  resolved "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz"
   integrity sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==
   dependencies:
     d3-array "1 - 2"
@@ -2010,7 +1406,7 @@ d3-sankey@^0.12.3:
 
 d3-scale-chromatic@3:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#34c39da298b23c20e02f1a4b239bd0f22e7f1314"
+  resolved "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz"
   integrity sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==
   dependencies:
     d3-color "1 - 3"
@@ -2018,7 +1414,7 @@ d3-scale-chromatic@3:
 
 d3-scale@4:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  resolved "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz"
   integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
   dependencies:
     d3-array "2.10.0 - 3"
@@ -2029,45 +1425,45 @@ d3-scale@4:
 
 "d3-selection@2 - 3", d3-selection@3:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  resolved "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
-
-d3-shape@3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
-  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
-  dependencies:
-    d3-path "^3.1.0"
 
 d3-shape@^1.2.0:
   version "1.3.7"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  resolved "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz"
   integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
   dependencies:
     d3-path "1"
 
+d3-shape@3:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
 "d3-time-format@2 - 4", d3-time-format@4:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  resolved "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz"
   integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
   dependencies:
     d3-time "1 - 3"
 
 "d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  resolved "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
   dependencies:
     d3-array "2 - 3"
 
 "d3-timer@1 - 3", d3-timer@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  resolved "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
 "d3-transition@2 - 3", d3-transition@3:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  resolved "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz"
   integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
   dependencies:
     d3-color "1 - 3"
@@ -2078,7 +1474,7 @@ d3-shape@^1.2.0:
 
 d3-zoom@3:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  resolved "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz"
   integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
   dependencies:
     d3-dispatch "1 - 3"
@@ -2089,7 +1485,7 @@ d3-zoom@3:
 
 d3@^7.9.0:
   version "7.9.0"
-  resolved "https://registry.yarnpkg.com/d3/-/d3-7.9.0.tgz#579e7acb3d749caf8860bd1741ae8d371070cd5d"
+  resolved "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz"
   integrity sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==
   dependencies:
     d3-array "3"
@@ -2125,7 +1521,7 @@ d3@^7.9.0:
 
 dagre-d3-es@7.0.13:
   version "7.0.13"
-  resolved "https://registry.yarnpkg.com/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz#acfb4b449f6dcdd48d8ea8081a6d8c59bc8128c3"
+  resolved "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz"
   integrity sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==
   dependencies:
     d3 "^7.9.0"
@@ -2133,87 +1529,87 @@ dagre-d3-es@7.0.13:
 
 dayjs@^1.11.18:
   version "1.11.19"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.19.tgz#15dc98e854bb43917f12021806af897c58ae2938"
+  resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz"
   integrity sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==
 
 debug@^4.0.0, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
 decode-named-character-reference@^1.0.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz#3e40603760874c2e5867691b599d73a7da25b53f"
+  resolved "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz"
   integrity sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==
   dependencies:
     character-entities "^2.0.0"
 
 defu@^6.1.4:
   version "6.1.4"
-  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.4.tgz#4e0c9cf9ff68fe5f3d7f2765cc1a012dfdcb0479"
+  resolved "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz"
   integrity sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==
 
 delaunator@5:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.1.tgz#39032b08053923e924d6094fe2cde1a99cc51278"
+  resolved "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz"
   integrity sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==
   dependencies:
     robust-predicates "^3.0.2"
 
 dequal@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  resolved "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
 destr@^2.0.5:
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.5.tgz#7d112ff1b925fb8d2079fac5bdb4a90973b51fdb"
+  resolved "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz"
   integrity sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==
 
 detect-libc@^2.0.3, detect-libc@^2.1.2:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 deterministic-object-hash@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz#b251ddc801443905f0e9fef08816a46bc9fe3807"
+  resolved "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz"
   integrity sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==
   dependencies:
     base-64 "^1.0.0"
 
 devalue@^5.6.2:
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/devalue/-/devalue-5.6.3.tgz#fee7b50bf072f4a4cdf18d1f27de3ce92131f699"
-  integrity sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==
+  version "5.6.2"
+  resolved "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz"
+  integrity sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==
 
 devlop@^1.0.0, devlop@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  resolved "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz"
   integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
   dependencies:
     dequal "^2.0.0"
 
 diff@^8.0.3:
   version "8.0.3"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
+  resolved "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz"
   integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
 
 direction@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/direction/-/direction-2.0.1.tgz#71800dd3c4fa102406502905d3866e65bdebb985"
+  resolved "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz"
   integrity sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==
 
 dlv@^1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
+  resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
 dom-serializer@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz"
   integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
   dependencies:
     domelementtype "^2.3.0"
@@ -2222,26 +1618,26 @@ dom-serializer@^2.0.0:
 
 domelementtype@^2.3.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
 domhandler@^5.0.2, domhandler@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  resolved "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz"
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
 
 dompurify@^3.2.5:
   version "3.3.1"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.1.tgz#c7e1ddebfe3301eacd6c0c12a4af284936dbbb86"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz"
   integrity sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
 domutils@^3.0.1:
   version "3.2.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  resolved "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz"
   integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
   dependencies:
     dom-serializer "^2.0.0"
@@ -2250,42 +1646,42 @@ domutils@^3.0.1:
 
 dset@^3.1.4:
   version "3.1.4"
-  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.4.tgz#f8eaf5f023f068a036d08cd07dc9ffb7d0065248"
+  resolved "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz"
   integrity sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==
 
 emoji-regex-xs@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz#e8af22e5d9dbd7f7f22d280af3d19d2aab5b0724"
+  resolved "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz"
   integrity sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==
 
 emoji-regex@^10.3.0:
   version "10.6.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz"
   integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 entities@^4.2.0:
   version "4.5.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 entities@^6.0.0:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  resolved "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz"
   integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 es-module-lexer@^1.7.0:
   version "1.7.0"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  resolved "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz"
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
 esast-util-from-estree@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz#8d1cfb51ad534d2f159dc250e604f3478a79f1ad"
+  resolved "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz"
   integrity sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -2295,7 +1691,7 @@ esast-util-from-estree@^2.0.0:
 
 esast-util-from-js@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz#5147bec34cc9da44accf52f87f239a40ac3e8225"
+  resolved "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz"
   integrity sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -2305,7 +1701,7 @@ esast-util-from-js@^2.0.0:
 
 esbuild@^0.25.0:
   version "0.25.12"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.12.tgz#97a1d041f4ab00c2fce2f838d2b9969a2d2a97a5"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz"
   integrity sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==
   optionalDependencies:
     "@esbuild/aix-ppc64" "0.25.12"
@@ -2335,9 +1731,9 @@ esbuild@^0.25.0:
     "@esbuild/win32-ia32" "0.25.12"
     "@esbuild/win32-x64" "0.25.12"
 
-esbuild@^0.27.3:
+esbuild@^0.27.0:
   version "0.27.3"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.27.3.tgz#5859ca8e70a3af956b26895ce4954d7e73bd27a8"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz"
   integrity sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==
   optionalDependencies:
     "@esbuild/aix-ppc64" "0.27.3"
@@ -2369,19 +1765,19 @@ esbuild@^0.27.3:
 
 escape-string-regexp@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz"
   integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 estree-util-attach-comments@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz#344bde6a64c8a31d15231e5ee9e297566a691c2d"
+  resolved "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz"
   integrity sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==
   dependencies:
     "@types/estree" "^1.0.0"
 
 estree-util-build-jsx@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz#b6d0bced1dcc4f06f25cf0ceda2b2dcaf98168f1"
+  resolved "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz"
   integrity sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -2391,12 +1787,12 @@ estree-util-build-jsx@^3.0.0:
 
 estree-util-is-identifier-name@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz#0b5ef4c4ff13508b34dcd01ecfa945f61fce5dbd"
+  resolved "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz"
   integrity sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==
 
 estree-util-scope@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/estree-util-scope/-/estree-util-scope-1.0.0.tgz#9cbdfc77f5cb51e3d9ed4ad9c4adbff22d43e585"
+  resolved "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz"
   integrity sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -2404,7 +1800,7 @@ estree-util-scope@^1.0.0:
 
 estree-util-to-js@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz#10a6fb924814e6abb62becf0d2bc4dea51d04f17"
+  resolved "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz"
   integrity sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -2413,7 +1809,7 @@ estree-util-to-js@^2.0.0:
 
 estree-util-visit@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/estree-util-visit/-/estree-util-visit-2.0.0.tgz#13a9a9f40ff50ed0c022f831ddf4b58d05446feb"
+  resolved "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz"
   integrity sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -2421,24 +1817,24 @@ estree-util-visit@^2.0.0:
 
 estree-walker@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 estree-walker@^3.0.0, estree-walker@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz"
   integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
   dependencies:
     "@types/estree" "^1.0.0"
 
 eventemitter3@^5.0.1:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz"
   integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
 
 expressive-code@^0.40.2:
   version "0.40.2"
-  resolved "https://registry.yarnpkg.com/expressive-code/-/expressive-code-0.40.2.tgz#34eca86bcfa54716c6887a860ca59682b2d983e6"
+  resolved "https://registry.npmjs.org/expressive-code/-/expressive-code-0.40.2.tgz"
   integrity sha512-1zIda2rB0qiDZACawzw2rbdBQiWHBT56uBctS+ezFe5XMAaFaHLnnSYND/Kd+dVzO9HfCXRDpzH3d+3fvOWRcw==
   dependencies:
     "@expressive-code/core" "^0.40.2"
@@ -2448,51 +1844,46 @@ expressive-code@^0.40.2:
 
 extend@^3.0.0:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 fdir@^6.4.4, fdir@^6.5.0:
   version "6.5.0"
-  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 flattie@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/flattie/-/flattie-1.1.1.tgz#88182235723113667d36217fec55359275d6fe3d"
+  resolved "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz"
   integrity sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==
 
 fontace@~0.4.0:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/fontace/-/fontace-0.4.1.tgz#de2a76cf361088016901a6f2a8f2bd016c9ae844"
+  resolved "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz"
   integrity sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==
   dependencies:
     fontkitten "^1.0.2"
 
 fontkitten@^1.0.0, fontkitten@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fontkitten/-/fontkitten-1.0.2.tgz#7f995d7e2b82f19917662064aa8a4d74d15f2292"
+  resolved "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.2.tgz"
   integrity sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q==
   dependencies:
     tiny-inflate "^1.0.3"
 
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 get-east-asian-width@^1.0.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz#ce7008fe345edcf5497a6f557cfa54bc318a9ce7"
-  integrity sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz"
+  integrity sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==
 
 github-slugger@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-2.0.0.tgz#52cf2f9279a21eb6c59dd385b410f0c0adda8f1a"
+  resolved "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz"
   integrity sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==
 
 h3@^1.15.5:
   version "1.15.5"
-  resolved "https://registry.yarnpkg.com/h3/-/h3-1.15.5.tgz#e2f28d4a66a249973bb050eaddb06b9ab55506f8"
+  resolved "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz"
   integrity sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==
   dependencies:
     cookie-es "^1.2.2"
@@ -2507,12 +1898,12 @@ h3@^1.15.5:
 
 hachure-fill@^0.5.2:
   version "0.5.2"
-  resolved "https://registry.yarnpkg.com/hachure-fill/-/hachure-fill-0.5.2.tgz#d19bc4cc8750a5962b47fb1300557a85fcf934cc"
+  resolved "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz"
   integrity sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==
 
 hast-util-embedded@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz#be4477780fbbe079cdba22982e357a0de4ba853e"
+  resolved "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz"
   integrity sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2520,7 +1911,7 @@ hast-util-embedded@^3.0.0:
 
 hast-util-format@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/hast-util-format/-/hast-util-format-1.1.0.tgz#373e77382e07deb04f6676f1b4437e7d8549d985"
+  resolved "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz"
   integrity sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2533,7 +1924,7 @@ hast-util-format@^1.0.0:
 
 hast-util-from-html@^2.0.0, hast-util-from-html@^2.0.1, hast-util-from-html@^2.0.3:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz#485c74785358beb80c4ba6346299311ac4c49c82"
+  resolved "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz"
   integrity sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2545,7 +1936,7 @@ hast-util-from-html@^2.0.0, hast-util-from-html@^2.0.1, hast-util-from-html@^2.0
 
 hast-util-from-parse5@^8.0.0:
   version "8.0.3"
-  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
+  resolved "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz"
   integrity sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2559,28 +1950,28 @@ hast-util-from-parse5@^8.0.0:
 
 hast-util-has-property@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz#4e595e3cddb8ce530ea92f6fc4111a818d8e7f93"
+  resolved "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz"
   integrity sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==
   dependencies:
     "@types/hast" "^3.0.0"
 
 hast-util-is-body-ok-link@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz#ef63cb2f14f04ecf775139cd92bda5026380d8b4"
+  resolved "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz"
   integrity sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==
   dependencies:
     "@types/hast" "^3.0.0"
 
 hast-util-is-element@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz#6e31a6532c217e5b533848c7e52c9d9369ca0932"
+  resolved "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz"
   integrity sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==
   dependencies:
     "@types/hast" "^3.0.0"
 
 hast-util-minify-whitespace@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz#7588fd1a53f48f1d30406b81959dffc3650daf55"
+  resolved "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz"
   integrity sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2591,14 +1982,14 @@ hast-util-minify-whitespace@^1.0.0:
 
 hast-util-parse-selector@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  resolved "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz"
   integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
   dependencies:
     "@types/hast" "^3.0.0"
 
 hast-util-phrasing@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz#fa284c0cd4a82a0dd6020de8300a7b1ebffa1690"
+  resolved "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz"
   integrity sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2609,7 +2000,7 @@ hast-util-phrasing@^3.0.0:
 
 hast-util-raw@^9.0.0:
   version "9.1.0"
-  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz#79b66b26f6f68fb50dfb4716b2cdca90d92adf2e"
+  resolved "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz"
   integrity sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2628,7 +2019,7 @@ hast-util-raw@^9.0.0:
 
 hast-util-select@^6.0.2:
   version "6.0.4"
-  resolved "https://registry.yarnpkg.com/hast-util-select/-/hast-util-select-6.0.4.tgz#1d8f69657a57441d0ce0ade35887874d3e65a303"
+  resolved "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz"
   integrity sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2649,7 +2040,7 @@ hast-util-select@^6.0.2:
 
 hast-util-to-estree@^3.0.0:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz#e654c1c9374645135695cc0ab9f70b8fcaf733d7"
+  resolved "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz"
   integrity sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -2671,7 +2062,7 @@ hast-util-to-estree@^3.0.0:
 
 hast-util-to-html@^9.0.0, hast-util-to-html@^9.0.1, hast-util-to-html@^9.0.4, hast-util-to-html@^9.0.5:
   version "9.0.5"
-  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz#ccc673a55bb8e85775b08ac28380f72d47167005"
+  resolved "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz"
   integrity sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2688,7 +2079,7 @@ hast-util-to-html@^9.0.0, hast-util-to-html@^9.0.1, hast-util-to-html@^9.0.4, ha
 
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
-  resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz#ff31897aae59f62232e21594eac7ef6b63333e98"
+  resolved "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz"
   integrity sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -2709,7 +2100,7 @@ hast-util-to-jsx-runtime@^2.0.0:
 
 hast-util-to-parse5@^8.0.0:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz#95aa391cc0514b4951418d01c883d1038af42f5d"
+  resolved "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz"
   integrity sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2722,14 +2113,14 @@ hast-util-to-parse5@^8.0.0:
 
 hast-util-to-string@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz#a4f15e682849326dd211c97129c94b0c3e76527c"
+  resolved "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz"
   integrity sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==
   dependencies:
     "@types/hast" "^3.0.0"
 
 hast-util-to-text@^4.0.1, hast-util-to-text@^4.0.2:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz#57b676931e71bf9cb852453678495b3080bfae3e"
+  resolved "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz"
   integrity sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2739,14 +2130,14 @@ hast-util-to-text@^4.0.1, hast-util-to-text@^4.0.2:
 
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
+  resolved "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz"
   integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
   dependencies:
     "@types/hast" "^3.0.0"
 
 hastscript@^9.0.0:
   version "9.0.1"
-  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  resolved "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz"
   integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -2757,71 +2148,71 @@ hastscript@^9.0.0:
 
 html-escaper@3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-3.0.3.tgz#4d336674652beb1dcbc29ef6b6ba7f6be6fdfed6"
+  resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz"
   integrity sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==
 
 html-void-elements@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz"
   integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 html-whitespace-sensitive-tag-names@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz#c35edd28205f3bf8c1fd03274608d60b923de5b2"
+  resolved "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz"
   integrity sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==
 
 http-cache-semantics@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz"
   integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
 
 i18next@^23.11.5:
   version "23.16.8"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.16.8.tgz#3ae1373d344c2393f465556f394aba5a9233b93a"
+  resolved "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz"
   integrity sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==
   dependencies:
     "@babel/runtime" "^7.23.2"
 
 iconv-lite@0.6:
   version "0.6.3"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
 import-meta-resolve@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz#08cb85b5bd37ecc8eb1e0f670dc2767002d43734"
+  resolved "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz"
   integrity sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==
 
 inline-style-parser@0.2.7:
   version "0.2.7"
-  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.2.7.tgz#b1fc68bfc0313b8685745e4464e37f9376b9c909"
+  resolved "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz"
   integrity sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==
-
-"internmap@1 - 2":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
-  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 internmap@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
+  resolved "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz"
   integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 iron-webcrypto@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz#aa60ff2aa10550630f4c0b11fd2442becdb35a6f"
+  resolved "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz"
   integrity sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==
 
 is-alphabetical@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
+  resolved "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz"
   integrity sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==
 
 is-alphanumerical@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz#7c03fbe96e3e931113e57f964b0a368cc2dfd875"
+  resolved "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz"
   integrity sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==
   dependencies:
     is-alphabetical "^2.0.0"
@@ -2829,80 +2220,80 @@ is-alphanumerical@^2.0.0:
 
 is-arrayish@^0.3.1:
   version "0.3.4"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.4.tgz#1ee5553818511915685d33bb13d31bf854e5059d"
+  resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz"
   integrity sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==
 
 is-decimal@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
+  resolved "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz"
   integrity sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==
 
 is-docker@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  resolved "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz"
   integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-hexadecimal@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz#86b5bf668fca307498d319dfc03289d781a90027"
+  resolved "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz"
   integrity sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==
 
 is-inside-container@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  resolved "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz"
   integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
   dependencies:
     is-docker "^3.0.0"
 
 is-plain-obj@^4.0.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
 is-wsl@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-3.1.1.tgz#327897b26832a3eb117da6c27492d04ca132594f"
+  resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz"
   integrity sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==
   dependencies:
     is-inside-container "^1.0.0"
 
 js-yaml@^4.1.0, js-yaml@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 
 katex@^0.16.22:
-  version "0.16.32"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.32.tgz#4f0cbfb68db20f2ea333173c35e8e45d729a65fa"
-  integrity sha512-ac0FzkRJlpw4WyH3Zu/OgU9LmPKqjHr6O2BxfSrBt8uJ1BhvH2YK3oJ4ut/K+O+6qQt2MGpdbn0MrffVEnnUDQ==
+  version "0.16.28"
+  resolved "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz"
+  integrity sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==
   dependencies:
     commander "^8.3.0"
 
 khroma@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/khroma/-/khroma-2.1.0.tgz#45f2ce94ce231a437cf5b63c2e886e6eb42bbbb1"
+  resolved "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz"
   integrity sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==
 
 kleur@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  resolved "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
 klona@^2.0.6:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
+  resolved "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz"
   integrity sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==
 
 langium@^4.0.0:
   version "4.2.1"
-  resolved "https://registry.yarnpkg.com/langium/-/langium-4.2.1.tgz#23e9e12d79778578efa912e3ca8fe313aa61ac17"
+  resolved "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz"
   integrity sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==
   dependencies:
     chevrotain "~11.1.1"
@@ -2913,39 +2304,39 @@ langium@^4.0.0:
 
 layout-base@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
+  resolved "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz"
   integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
 
 layout-base@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-2.0.1.tgz#d0337913586c90f9c2c075292069f5c2da5dd285"
+  resolved "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz"
   integrity sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==
 
-lodash-es@4.17.23, lodash-es@^4.17.21, lodash-es@^4.17.23:
+lodash-es@^4.17.21, lodash-es@^4.17.23, lodash-es@4.17.23:
   version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
+  resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz"
   integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
 
 longest-streak@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
+  resolved "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz"
   integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
 
 lru-cache@^11.2.0:
   version "11.2.6"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.6.tgz#356bf8a29e88a7a2945507b31f6429a65a192c58"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz"
   integrity sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==
 
 magic-string@^0.30.21:
   version "0.30.21"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
 magicast@^0.5.1:
   version "0.5.2"
-  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.5.2.tgz#70cea9df729c164485049ea5df85a390281dfb9d"
+  resolved "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz"
   integrity sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==
   dependencies:
     "@babel/parser" "^7.29.0"
@@ -2954,22 +2345,22 @@ magicast@^0.5.1:
 
 markdown-extensions@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/markdown-extensions/-/markdown-extensions-2.0.0.tgz#34bebc83e9938cae16e0e017e4a9814a8330d3c4"
+  resolved "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz"
   integrity sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==
 
 markdown-table@^3.0.0:
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.4.tgz#fe44d6d410ff9d6f2ea1797a3f60aa4d2b631c2a"
+  resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz"
   integrity sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==
 
 marked@^16.2.1:
   version "16.4.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-16.4.2.tgz#4959a64be6c486f0db7467ead7ce288de54290a3"
+  resolved "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz"
   integrity sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==
 
 mdast-util-definitions@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz#c1bb706e5e76bb93f9a09dd7af174002ae69ac24"
+  resolved "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz"
   integrity sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -2978,7 +2369,7 @@ mdast-util-definitions@^6.0.0:
 
 mdast-util-directive@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz#f3656f4aab6ae3767d3c72cfab5e8055572ccba1"
+  resolved "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz"
   integrity sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -2993,7 +2384,7 @@ mdast-util-directive@^3.0.0:
 
 mdast-util-find-and-replace@^3.0.0:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz#70a3174c894e14df722abf43bc250cbae44b11df"
+  resolved "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz"
   integrity sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -3002,9 +2393,9 @@ mdast-util-find-and-replace@^3.0.0:
     unist-util-visit-parents "^6.0.0"
 
 mdast-util-from-markdown@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz#c95822b91aab75f18a4cbe8b2f51b873ed2cf0c7"
-  integrity sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz"
+  integrity sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==
   dependencies:
     "@types/mdast" "^4.0.0"
     "@types/unist" "^3.0.0"
@@ -3021,7 +2412,7 @@ mdast-util-from-markdown@^2.0.0:
 
 mdast-util-gfm-autolink-literal@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz#abd557630337bd30a6d5a4bd8252e1c2dc0875d5"
+  resolved "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz"
   integrity sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -3032,7 +2423,7 @@ mdast-util-gfm-autolink-literal@^2.0.0:
 
 mdast-util-gfm-footnote@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz#7778e9d9ca3df7238cc2bd3fa2b1bf6a65b19403"
+  resolved "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz"
   integrity sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -3043,7 +2434,7 @@ mdast-util-gfm-footnote@^2.0.0:
 
 mdast-util-gfm-strikethrough@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz#d44ef9e8ed283ac8c1165ab0d0dfd058c2764c16"
+  resolved "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz"
   integrity sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -3052,7 +2443,7 @@ mdast-util-gfm-strikethrough@^2.0.0:
 
 mdast-util-gfm-table@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz#7a435fb6223a72b0862b33afbd712b6dae878d38"
+  resolved "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz"
   integrity sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -3063,7 +2454,7 @@ mdast-util-gfm-table@^2.0.0:
 
 mdast-util-gfm-task-list-item@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz#e68095d2f8a4303ef24094ab642e1047b991a936"
+  resolved "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz"
   integrity sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -3073,7 +2464,7 @@ mdast-util-gfm-task-list-item@^2.0.0:
 
 mdast-util-gfm@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz#2cdf63b92c2a331406b0fb0db4c077c1b0331751"
+  resolved "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz"
   integrity sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==
   dependencies:
     mdast-util-from-markdown "^2.0.0"
@@ -3086,7 +2477,7 @@ mdast-util-gfm@^3.0.0:
 
 mdast-util-mdx-expression@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz#43f0abac9adc756e2086f63822a38c8d3c3a5096"
+  resolved "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz"
   integrity sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -3098,7 +2489,7 @@ mdast-util-mdx-expression@^2.0.0:
 
 mdast-util-mdx-jsx@^3.0.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz#fd04c67a2a7499efb905a8a5c578dddc9fdada0d"
+  resolved "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz"
   integrity sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -3116,7 +2507,7 @@ mdast-util-mdx-jsx@^3.0.0:
 
 mdast-util-mdx@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz#792f9cf0361b46bee1fdf1ef36beac424a099c41"
+  resolved "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz"
   integrity sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==
   dependencies:
     mdast-util-from-markdown "^2.0.0"
@@ -3127,7 +2518,7 @@ mdast-util-mdx@^3.0.0:
 
 mdast-util-mdxjs-esm@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz#019cfbe757ad62dd557db35a695e7314bcc9fa97"
+  resolved "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz"
   integrity sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==
   dependencies:
     "@types/estree-jsx" "^1.0.0"
@@ -3139,7 +2530,7 @@ mdast-util-mdxjs-esm@^2.0.0:
 
 mdast-util-phrasing@^4.0.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz#7cc0a8dec30eaf04b7b1a9661a92adb3382aa6e3"
+  resolved "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz"
   integrity sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -3147,7 +2538,7 @@ mdast-util-phrasing@^4.0.0:
 
 mdast-util-to-hast@^13.0.0:
   version "13.2.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz#d7ff84ca499a57e2c060ae67548ad950e689a053"
+  resolved "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz"
   integrity sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -3162,7 +2553,7 @@ mdast-util-to-hast@^13.0.0:
 
 mdast-util-to-markdown@^2.0.0, mdast-util-to-markdown@^2.1.0:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz#f910ffe60897f04bb4b7e7ee434486f76288361b"
+  resolved "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz"
   integrity sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -3177,24 +2568,24 @@ mdast-util-to-markdown@^2.0.0, mdast-util-to-markdown@^2.1.0:
 
 mdast-util-to-string@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz#7a5121475556a04e7eddeb67b264aae79d312814"
+  resolved "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz"
   integrity sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==
   dependencies:
     "@types/mdast" "^4.0.0"
 
 mdn-data@2.0.28:
   version "2.0.28"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.28.tgz#5ec48e7bef120654539069e1ae4ddc81ca490eba"
+  resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz"
   integrity sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==
 
 mdn-data@2.12.2:
   version "2.12.2"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.12.2.tgz#9ae6c41a9e65adf61318b32bff7b64fbfb13f8cf"
+  resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz"
   integrity sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==
 
-mermaid@^11.12.3:
+"mermaid@^10.0.0 || ^11.0.0", mermaid@^11.12.3:
   version "11.12.3"
-  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-11.12.3.tgz#e150dae69ca291254fb408cf36d001b2efad62bf"
+  resolved "https://registry.npmjs.org/mermaid/-/mermaid-11.12.3.tgz"
   integrity sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==
   dependencies:
     "@braintree/sanitize-url" "^7.1.1"
@@ -3220,7 +2611,7 @@ mermaid@^11.12.3:
 
 micromark-core-commonmark@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz#c691630e485021a68cf28dbc2b2ca27ebf678cd4"
+  resolved "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz"
   integrity sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==
   dependencies:
     decode-named-character-reference "^1.0.0"
@@ -3242,7 +2633,7 @@ micromark-core-commonmark@^2.0.0:
 
 micromark-extension-directive@^3.0.0:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz#2eb61985d1995a7c1ff7621676a4f32af29409e8"
+  resolved "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz"
   integrity sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==
   dependencies:
     devlop "^1.0.0"
@@ -3255,7 +2646,7 @@ micromark-extension-directive@^3.0.0:
 
 micromark-extension-gfm-autolink-literal@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz#6286aee9686c4462c1e3552a9d505feddceeb935"
+  resolved "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz"
   integrity sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==
   dependencies:
     micromark-util-character "^2.0.0"
@@ -3265,7 +2656,7 @@ micromark-extension-gfm-autolink-literal@^2.0.0:
 
 micromark-extension-gfm-footnote@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz#4dab56d4e398b9853f6fe4efac4fc9361f3e0750"
+  resolved "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz"
   integrity sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==
   dependencies:
     devlop "^1.0.0"
@@ -3279,7 +2670,7 @@ micromark-extension-gfm-footnote@^2.0.0:
 
 micromark-extension-gfm-strikethrough@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz#86106df8b3a692b5f6a92280d3879be6be46d923"
+  resolved "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz"
   integrity sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==
   dependencies:
     devlop "^1.0.0"
@@ -3291,7 +2682,7 @@ micromark-extension-gfm-strikethrough@^2.0.0:
 
 micromark-extension-gfm-table@^2.0.0:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz#fac70bcbf51fe65f5f44033118d39be8a9b5940b"
+  resolved "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz"
   integrity sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==
   dependencies:
     devlop "^1.0.0"
@@ -3302,14 +2693,14 @@ micromark-extension-gfm-table@^2.0.0:
 
 micromark-extension-gfm-tagfilter@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz#f26d8a7807b5985fba13cf61465b58ca5ff7dc57"
+  resolved "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz"
   integrity sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==
   dependencies:
     micromark-util-types "^2.0.0"
 
 micromark-extension-gfm-task-list-item@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz#bcc34d805639829990ec175c3eea12bb5b781f2c"
+  resolved "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz"
   integrity sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==
   dependencies:
     devlop "^1.0.0"
@@ -3320,7 +2711,7 @@ micromark-extension-gfm-task-list-item@^2.0.0:
 
 micromark-extension-gfm@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz#3e13376ab95dd7a5cfd0e29560dfe999657b3c5b"
+  resolved "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz"
   integrity sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==
   dependencies:
     micromark-extension-gfm-autolink-literal "^2.0.0"
@@ -3334,7 +2725,7 @@ micromark-extension-gfm@^3.0.0:
 
 micromark-extension-mdx-expression@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz#43d058d999532fb3041195a3c3c05c46fa84543b"
+  resolved "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz"
   integrity sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -3348,7 +2739,7 @@ micromark-extension-mdx-expression@^3.0.0:
 
 micromark-extension-mdx-jsx@^3.0.0:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz#ffc98bdb649798902fa9fc5689f67f9c1c902044"
+  resolved "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz"
   integrity sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -3364,14 +2755,14 @@ micromark-extension-mdx-jsx@^3.0.0:
 
 micromark-extension-mdx-md@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz#1d252881ea35d74698423ab44917e1f5b197b92d"
+  resolved "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz"
   integrity sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==
   dependencies:
     micromark-util-types "^2.0.0"
 
 micromark-extension-mdxjs-esm@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz#de21b2b045fd2059bd00d36746081de38390d54a"
+  resolved "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz"
   integrity sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -3386,7 +2777,7 @@ micromark-extension-mdxjs-esm@^3.0.0:
 
 micromark-extension-mdxjs@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz#b5a2e0ed449288f3f6f6c544358159557549de18"
+  resolved "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz"
   integrity sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==
   dependencies:
     acorn "^8.0.0"
@@ -3400,7 +2791,7 @@ micromark-extension-mdxjs@^3.0.0:
 
 micromark-factory-destination@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz#8fef8e0f7081f0474fbdd92deb50c990a0264639"
+  resolved "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz"
   integrity sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==
   dependencies:
     micromark-util-character "^2.0.0"
@@ -3409,7 +2800,7 @@ micromark-factory-destination@^2.0.0:
 
 micromark-factory-label@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz#5267efa97f1e5254efc7f20b459a38cb21058ba1"
+  resolved "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz"
   integrity sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==
   dependencies:
     devlop "^1.0.0"
@@ -3419,7 +2810,7 @@ micromark-factory-label@^2.0.0:
 
 micromark-factory-mdx-expression@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz#bb09988610589c07d1c1e4425285895041b3dfa9"
+  resolved "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz"
   integrity sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -3434,7 +2825,7 @@ micromark-factory-mdx-expression@^2.0.0:
 
 micromark-factory-space@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz#36d0212e962b2b3121f8525fc7a3c7c029f334fc"
+  resolved "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz"
   integrity sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==
   dependencies:
     micromark-util-character "^2.0.0"
@@ -3442,7 +2833,7 @@ micromark-factory-space@^2.0.0:
 
 micromark-factory-title@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz#237e4aa5d58a95863f01032d9ee9b090f1de6e94"
+  resolved "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz"
   integrity sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==
   dependencies:
     micromark-factory-space "^2.0.0"
@@ -3452,7 +2843,7 @@ micromark-factory-title@^2.0.0:
 
 micromark-factory-whitespace@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz#06b26b2983c4d27bfcc657b33e25134d4868b0b1"
+  resolved "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz"
   integrity sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==
   dependencies:
     micromark-factory-space "^2.0.0"
@@ -3462,7 +2853,7 @@ micromark-factory-whitespace@^2.0.0:
 
 micromark-util-character@^2.0.0:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz#2f987831a40d4c510ac261e89852c4e9703ccda6"
+  resolved "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz"
   integrity sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
   dependencies:
     micromark-util-symbol "^2.0.0"
@@ -3470,14 +2861,14 @@ micromark-util-character@^2.0.0:
 
 micromark-util-chunked@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz#47fbcd93471a3fccab86cff03847fc3552db1051"
+  resolved "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz"
   integrity sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==
   dependencies:
     micromark-util-symbol "^2.0.0"
 
 micromark-util-classify-character@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz#d399faf9c45ca14c8b4be98b1ea481bced87b629"
+  resolved "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz"
   integrity sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==
   dependencies:
     micromark-util-character "^2.0.0"
@@ -3486,7 +2877,7 @@ micromark-util-classify-character@^2.0.0:
 
 micromark-util-combine-extensions@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz#2a0f490ab08bff5cc2fd5eec6dd0ca04f89b30a9"
+  resolved "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz"
   integrity sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==
   dependencies:
     micromark-util-chunked "^2.0.0"
@@ -3494,14 +2885,14 @@ micromark-util-combine-extensions@^2.0.0:
 
 micromark-util-decode-numeric-character-reference@^2.0.0:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz#fcf15b660979388e6f118cdb6bf7d79d73d26fe5"
+  resolved "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz"
   integrity sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==
   dependencies:
     micromark-util-symbol "^2.0.0"
 
 micromark-util-decode-string@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz#6cb99582e5d271e84efca8e61a807994d7161eb2"
+  resolved "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz"
   integrity sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==
   dependencies:
     decode-named-character-reference "^1.0.0"
@@ -3511,12 +2902,12 @@ micromark-util-decode-string@^2.0.0:
 
 micromark-util-encode@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz#0d51d1c095551cfaac368326963cf55f15f540b8"
+  resolved "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz"
   integrity sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
 
 micromark-util-events-to-acorn@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz#e7a8a6b55a47e5a06c720d5a1c4abae8c37c98f3"
+  resolved "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz"
   integrity sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -3529,26 +2920,26 @@ micromark-util-events-to-acorn@^2.0.0:
 
 micromark-util-html-tag-name@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz#e40403096481986b41c106627f98f72d4d10b825"
+  resolved "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz"
   integrity sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==
 
 micromark-util-normalize-identifier@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz#c30d77b2e832acf6526f8bf1aa47bc9c9438c16d"
+  resolved "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz"
   integrity sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==
   dependencies:
     micromark-util-symbol "^2.0.0"
 
 micromark-util-resolve-all@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz#e1a2d62cdd237230a2ae11839027b19381e31e8b"
+  resolved "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz"
   integrity sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==
   dependencies:
     micromark-util-types "^2.0.0"
 
 micromark-util-sanitize-uri@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz#ab89789b818a58752b73d6b55238621b7faa8fd7"
+  resolved "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz"
   integrity sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
   dependencies:
     micromark-util-character "^2.0.0"
@@ -3557,7 +2948,7 @@ micromark-util-sanitize-uri@^2.0.0:
 
 micromark-util-subtokenize@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz#d8ade5ba0f3197a1cf6a2999fbbfe6357a1a19ee"
+  resolved "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz"
   integrity sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==
   dependencies:
     devlop "^1.0.0"
@@ -3567,17 +2958,17 @@ micromark-util-subtokenize@^2.0.0:
 
 micromark-util-symbol@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz#e5da494e8eb2b071a0d08fb34f6cefec6c0a19b8"
+  resolved "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz"
   integrity sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
 
 micromark-util-types@^2.0.0:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.2.tgz#f00225f5f5a0ebc3254f96c36b6605c4b393908e"
+  resolved "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz"
   integrity sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
 
 micromark@^4.0.0:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromark/-/micromark-4.0.2.tgz#91395a3e1884a198e62116e33c9c568e39936fdb"
+  resolved "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz"
   integrity sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==
   dependencies:
     "@types/debug" "^4.0.0"
@@ -3600,7 +2991,7 @@ micromark@^4.0.0:
 
 mlly@^1.7.4, mlly@^1.8.0:
   version "1.8.0"
-  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.8.0.tgz#e074612b938af8eba1eaf43299cbc89cb72d824e"
+  resolved "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz"
   integrity sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==
   dependencies:
     acorn "^8.15.0"
@@ -3610,56 +3001,56 @@ mlly@^1.7.4, mlly@^1.8.0:
 
 mrmime@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.1.tgz#bc3e87f7987853a54c9850eeb1f1078cd44adddc"
+  resolved "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz"
   integrity sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==
 
 ms@^2.1.3:
   version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 nanoid@^3.3.11:
   version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
 neotraverse@^0.6.18:
   version "0.6.18"
-  resolved "https://registry.yarnpkg.com/neotraverse/-/neotraverse-0.6.18.tgz#abcb33dda2e8e713cf6321b29405e822230cdb30"
+  resolved "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz"
   integrity sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==
 
 nlcst-to-string@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz#05511e8461ebfb415952eb0b7e9a1a7d40471bd4"
+  resolved "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz"
   integrity sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==
   dependencies:
     "@types/nlcst" "^2.0.0"
 
 node-fetch-native@^1.6.7:
   version "1.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.7.tgz#9d09ca63066cc48423211ed4caf5d70075d76a71"
+  resolved "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz"
   integrity sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==
 
 node-mock-http@^1.0.4:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/node-mock-http/-/node-mock-http-1.0.4.tgz#21f2ab4ce2fe4fbe8a660d7c5195a1db85e042a4"
+  resolved "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz"
   integrity sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==
 
 normalize-path@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 nth-check@^2.0.0, nth-check@^2.0.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
 
 ofetch@^1.5.1:
   version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ofetch/-/ofetch-1.5.1.tgz#5c43cc56e03398b273014957060344254505c5c7"
+  resolved "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz"
   integrity sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==
   dependencies:
     destr "^2.0.5"
@@ -3668,17 +3059,17 @@ ofetch@^1.5.1:
 
 ohash@^2.0.11:
   version "2.0.11"
-  resolved "https://registry.yarnpkg.com/ohash/-/ohash-2.0.11.tgz#60b11e8cff62ca9dee88d13747a5baa145f5900b"
+  resolved "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz"
   integrity sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==
 
 oniguruma-parser@^0.12.1:
   version "0.12.1"
-  resolved "https://registry.yarnpkg.com/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz#82ba2208d7a2b69ee344b7efe0ae930c627dcc4a"
+  resolved "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz"
   integrity sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==
 
 oniguruma-to-es@^2.2.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz#35ea9104649b7c05f3963c6b3b474d964625028b"
+  resolved "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz"
   integrity sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==
   dependencies:
     emoji-regex-xs "^1.0.0"
@@ -3687,7 +3078,7 @@ oniguruma-to-es@^2.2.0:
 
 oniguruma-to-es@^4.3.4:
   version "4.3.4"
-  resolved "https://registry.yarnpkg.com/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz#0b909d960faeb84511c979b1f2af64e9bc37ce34"
+  resolved "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz"
   integrity sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==
   dependencies:
     oniguruma-parser "^0.12.1"
@@ -3696,14 +3087,14 @@ oniguruma-to-es@^4.3.4:
 
 p-limit@^6.2.0:
   version "6.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-6.2.0.tgz#c254d22ba6aeef441a3564c5e6c2f2da59268a0f"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz"
   integrity sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==
   dependencies:
     yocto-queue "^1.1.1"
 
 p-queue@^8.1.1:
   version "8.1.1"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-8.1.1.tgz#dac3e8c57412fffa18fe6c341b141dbb3a16408b"
+  resolved "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz"
   integrity sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==
   dependencies:
     eventemitter3 "^5.0.1"
@@ -3711,17 +3102,17 @@ p-queue@^8.1.1:
 
 p-timeout@^6.1.2:
   version "6.1.4"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-6.1.4.tgz#418e1f4dd833fa96a2e3f532547dd2abdb08dbc2"
+  resolved "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz"
   integrity sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==
 
 package-manager-detector@^1.3.0, package-manager-detector@^1.6.0:
   version "1.6.0"
-  resolved "https://registry.yarnpkg.com/package-manager-detector/-/package-manager-detector-1.6.0.tgz#70d0cf0aa02c877eeaf66c4d984ede0be9130734"
+  resolved "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz"
   integrity sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==
 
 pagefind@^1.3.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/pagefind/-/pagefind-1.4.0.tgz#0154b0a44b5ef9ef55c156824a3244bfc0c4008d"
+  resolved "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz"
   integrity sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==
   optionalDependencies:
     "@pagefind/darwin-arm64" "1.4.0"
@@ -3733,7 +3124,7 @@ pagefind@^1.3.0:
 
 parse-entities@^4.0.0:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-4.0.2.tgz#61d46f5ed28e4ee62e9ddc43d6b010188443f159"
+  resolved "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz"
   integrity sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==
   dependencies:
     "@types/unist" "^2.0.0"
@@ -3746,7 +3137,7 @@ parse-entities@^4.0.0:
 
 parse-latin@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/parse-latin/-/parse-latin-7.0.0.tgz#8dfacac26fa603f76417f36233fc45602a323e1d"
+  resolved "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz"
   integrity sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==
   dependencies:
     "@types/nlcst" "^2.0.0"
@@ -3758,58 +3149,58 @@ parse-latin@^7.0.0:
 
 parse5@^7.0.0:
   version "7.3.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz"
   integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
   dependencies:
     entities "^6.0.0"
 
-path-data-parser@0.1.0, path-data-parser@^0.1.0:
+path-data-parser@^0.1.0, path-data-parser@0.1.0:
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/path-data-parser/-/path-data-parser-0.1.0.tgz#8f5ba5cc70fc7becb3dcefaea08e2659aba60b8c"
+  resolved "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz"
   integrity sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==
 
 pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  resolved "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
 piccolore@^0.1.3:
   version "0.1.3"
-  resolved "https://registry.yarnpkg.com/piccolore/-/piccolore-0.1.3.tgz#ef33f6180e6a37b35fe12a45765a900171cfaedc"
+  resolved "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz"
   integrity sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==
 
 picocolors@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.2, picomatch@^4.0.3:
+"picomatch@^3 || ^4", picomatch@^4.0.2, picomatch@^4.0.3:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 pkg-types@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.3.1.tgz#bd7cc70881192777eef5326c19deb46e890917df"
+  resolved "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz"
   integrity sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==
   dependencies:
     confbox "^0.1.8"
     mlly "^1.7.4"
     pathe "^2.0.1"
 
-points-on-curve@0.2.0, points-on-curve@^0.2.0:
+points-on-curve@^0.2.0, points-on-curve@0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/points-on-curve/-/points-on-curve-0.2.0.tgz#7dbb98c43791859434284761330fa893cb81b4d1"
+  resolved "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz"
   integrity sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==
 
 points-on-path@^0.2.1:
   version "0.2.1"
-  resolved "https://registry.yarnpkg.com/points-on-path/-/points-on-path-0.2.1.tgz#553202b5424c53bed37135b318858eacff85dd52"
+  resolved "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz"
   integrity sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==
   dependencies:
     path-data-parser "0.1.0"
@@ -3817,22 +3208,22 @@ points-on-path@^0.2.1:
 
 postcss-nested@^6.0.1:
   version "6.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-6.2.0.tgz#4c2d22ab5f20b9cb61e2c5c5915950784d068131"
+  resolved "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz"
   integrity sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==
   dependencies:
     postcss-selector-parser "^6.1.1"
 
 postcss-selector-parser@^6.1.1:
   version "6.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz"
   integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss@^8.4.38, postcss@^8.5.3:
+postcss@^8.2.14, postcss@^8.4.38, postcss@^8.5.3:
   version "8.5.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz"
   integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
   dependencies:
     nanoid "^3.3.11"
@@ -3841,12 +3232,12 @@ postcss@^8.4.38, postcss@^8.5.3:
 
 prismjs@^1.30.0:
   version "1.30.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
+  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz"
   integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
 
 prompts@^2.4.2:
   version "2.4.2"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
+  resolved "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
   dependencies:
     kleur "^3.0.3"
@@ -3854,22 +3245,22 @@ prompts@^2.4.2:
 
 property-information@^7.0.0:
   version "7.1.0"
-  resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.1.0.tgz#b622e8646e02b580205415586b40804d3e8bfd5d"
+  resolved "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz"
   integrity sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
 
 radix3@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/radix3/-/radix3-1.1.2.tgz#fd27d2af3896c6bf4bcdfab6427c69c2afc69ec0"
+  resolved "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz"
   integrity sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==
 
 readdirp@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-5.0.0.tgz#fbf1f71a727891d685bb1786f9ba74084f6e2f91"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz"
   integrity sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==
 
 recma-build-jsx@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz#c02f29e047e103d2fab2054954e1761b8ea253c4"
+  resolved "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz"
   integrity sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -3878,7 +3269,7 @@ recma-build-jsx@^1.0.0:
 
 recma-jsx@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/recma-jsx/-/recma-jsx-1.0.1.tgz#58e718f45e2102ed0bf2fa994f05b70d76801a1a"
+  resolved "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz"
   integrity sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==
   dependencies:
     acorn-jsx "^5.0.0"
@@ -3889,7 +3280,7 @@ recma-jsx@^1.0.0:
 
 recma-parse@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/recma-parse/-/recma-parse-1.0.0.tgz#c351e161bb0ab47d86b92a98a9d891f9b6814b52"
+  resolved "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz"
   integrity sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -3899,7 +3290,7 @@ recma-parse@^1.0.0:
 
 recma-stringify@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/recma-stringify/-/recma-stringify-1.0.0.tgz#54632030631e0c7546136ff9ef8fde8e7b44f130"
+  resolved "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz"
   integrity sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -3909,7 +3300,7 @@ recma-stringify@^1.0.0:
 
 regex-recursion@^5.1.1:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/regex-recursion/-/regex-recursion-5.1.1.tgz#5a73772d18adbf00f57ad097bf54171b39d78f8b"
+  resolved "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz"
   integrity sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==
   dependencies:
     regex "^5.1.1"
@@ -3917,40 +3308,40 @@ regex-recursion@^5.1.1:
 
 regex-recursion@^6.0.2:
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/regex-recursion/-/regex-recursion-6.0.2.tgz#a0b1977a74c87f073377b938dbedfab2ea582b33"
+  resolved "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz"
   integrity sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==
   dependencies:
     regex-utilities "^2.3.0"
 
 regex-utilities@^2.3.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/regex-utilities/-/regex-utilities-2.3.0.tgz#87163512a15dce2908cf079c8960d5158ff43280"
+  resolved "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz"
   integrity sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
 
 regex@^5.1.1:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/regex/-/regex-5.1.1.tgz#cf798903f24d6fe6e531050a36686e082b29bd03"
+  resolved "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz"
   integrity sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==
   dependencies:
     regex-utilities "^2.3.0"
 
 regex@^6.0.1:
   version "6.1.0"
-  resolved "https://registry.yarnpkg.com/regex/-/regex-6.1.0.tgz#d7ce98f8ee32da7497c13f6601fca2bc4a6a7803"
+  resolved "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz"
   integrity sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==
   dependencies:
     regex-utilities "^2.3.0"
 
 rehype-expressive-code@^0.40.2:
   version "0.40.2"
-  resolved "https://registry.yarnpkg.com/rehype-expressive-code/-/rehype-expressive-code-0.40.2.tgz#93b0541796228eb59a318fbbb1db4a97a2c6a38a"
+  resolved "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.40.2.tgz"
   integrity sha512-+kn+AMGCrGzvtH8Q5lC6Y5lnmTV/r33fdmi5QU/IH1KPHKobKr5UnLwJuqHv5jBTSN/0v2wLDS7RTM73FVzqmQ==
   dependencies:
     expressive-code "^0.40.2"
 
 rehype-format@^5.0.0:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/rehype-format/-/rehype-format-5.0.1.tgz#e255e59bed0c062156aaf51c16fad5a521a1f5c8"
+  resolved "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz"
   integrity sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -3958,7 +3349,7 @@ rehype-format@^5.0.0:
 
 rehype-parse@^9.0.0:
   version "9.0.1"
-  resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-9.0.1.tgz#9993bda129acc64c417a9d3654a7be38b2a94c20"
+  resolved "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz"
   integrity sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -3967,7 +3358,7 @@ rehype-parse@^9.0.0:
 
 rehype-raw@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  resolved "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz"
   integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -3976,7 +3367,7 @@ rehype-raw@^7.0.0:
 
 rehype-recma@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rehype-recma/-/rehype-recma-1.0.0.tgz#d68ef6344d05916bd96e25400c6261775411aa76"
+  resolved "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz"
   integrity sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==
   dependencies:
     "@types/estree" "^1.0.0"
@@ -3985,7 +3376,7 @@ rehype-recma@^1.0.0:
 
 rehype-stringify@^10.0.0, rehype-stringify@^10.0.1:
   version "10.0.1"
-  resolved "https://registry.yarnpkg.com/rehype-stringify/-/rehype-stringify-10.0.1.tgz#2ec1ebc56c6aba07905d3b4470bdf0f684f30b75"
+  resolved "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz"
   integrity sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -3994,7 +3385,7 @@ rehype-stringify@^10.0.0, rehype-stringify@^10.0.1:
 
 rehype@^13.0.1, rehype@^13.0.2:
   version "13.0.2"
-  resolved "https://registry.yarnpkg.com/rehype/-/rehype-13.0.2.tgz#ab0b3ac26573d7b265a0099feffad450e4cf1952"
+  resolved "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz"
   integrity sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -4004,7 +3395,7 @@ rehype@^13.0.1, rehype@^13.0.2:
 
 remark-directive@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/remark-directive/-/remark-directive-3.0.1.tgz#689ba332f156cfe1118e849164cc81f157a3ef0a"
+  resolved "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz"
   integrity sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -4014,7 +3405,7 @@ remark-directive@^3.0.0:
 
 remark-gfm@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-4.0.1.tgz#33227b2a74397670d357bf05c098eaf8513f0d6b"
+  resolved "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz"
   integrity sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -4026,7 +3417,7 @@ remark-gfm@^4.0.1:
 
 remark-mdx@^3.0.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-3.1.1.tgz#047f97038bc7ec387aebb4b0a4fe23779999d845"
+  resolved "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz"
   integrity sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==
   dependencies:
     mdast-util-mdx "^3.0.0"
@@ -4034,7 +3425,7 @@ remark-mdx@^3.0.0:
 
 remark-parse@^11.0.0:
   version "11.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-11.0.0.tgz#aa60743fcb37ebf6b069204eb4da304e40db45a1"
+  resolved "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz"
   integrity sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -4044,7 +3435,7 @@ remark-parse@^11.0.0:
 
 remark-rehype@^11.0.0, remark-rehype@^11.1.2:
   version "11.1.2"
-  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-11.1.2.tgz#2addaadda80ca9bd9aa0da763e74d16327683b37"
+  resolved "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz"
   integrity sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==
   dependencies:
     "@types/hast" "^3.0.0"
@@ -4055,7 +3446,7 @@ remark-rehype@^11.0.0, remark-rehype@^11.1.2:
 
 remark-smartypants@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/remark-smartypants/-/remark-smartypants-3.0.2.tgz#cbaf2b39624c78fcbd6efa224678c1d2e9bc1dfb"
+  resolved "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz"
   integrity sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==
   dependencies:
     retext "^9.0.0"
@@ -4065,7 +3456,7 @@ remark-smartypants@^3.0.2:
 
 remark-stringify@^11.0.0:
   version "11.0.0"
-  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-11.0.0.tgz#4c5b01dd711c269df1aaae11743eb7e2e7636fd3"
+  resolved "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz"
   integrity sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==
   dependencies:
     "@types/mdast" "^4.0.0"
@@ -4074,7 +3465,7 @@ remark-stringify@^11.0.0:
 
 retext-latin@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/retext-latin/-/retext-latin-4.0.0.tgz#d02498aa1fd39f1bf00e2ff59b1384c05d0c7ce3"
+  resolved "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz"
   integrity sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==
   dependencies:
     "@types/nlcst" "^2.0.0"
@@ -4083,7 +3474,7 @@ retext-latin@^4.0.0:
 
 retext-smartypants@^6.0.0:
   version "6.2.0"
-  resolved "https://registry.yarnpkg.com/retext-smartypants/-/retext-smartypants-6.2.0.tgz#4e852c2974cf2cfa253eeec427c97efc43b5d158"
+  resolved "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz"
   integrity sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==
   dependencies:
     "@types/nlcst" "^2.0.0"
@@ -4092,7 +3483,7 @@ retext-smartypants@^6.0.0:
 
 retext-stringify@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/retext-stringify/-/retext-stringify-4.0.0.tgz#501d5440bd4d121e351c7c509f8507de9611e159"
+  resolved "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz"
   integrity sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==
   dependencies:
     "@types/nlcst" "^2.0.0"
@@ -4101,7 +3492,7 @@ retext-stringify@^4.0.0:
 
 retext@^9.0.0:
   version "9.0.0"
-  resolved "https://registry.yarnpkg.com/retext/-/retext-9.0.0.tgz#ab5cd72836894167b0ca6ae70fdcfaa166267f7a"
+  resolved "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz"
   integrity sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==
   dependencies:
     "@types/nlcst" "^2.0.0"
@@ -4111,46 +3502,46 @@ retext@^9.0.0:
 
 robust-predicates@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
+  resolved "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz"
   integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
 
-rollup@^4.34.9:
-  version "4.59.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.59.0.tgz#cf74edac17c1486f562d728a4d923a694abdf06f"
-  integrity sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==
+rollup@^1.20.0||^2.0.0||^3.0.0||^4.0.0, rollup@^4.34.9:
+  version "4.57.1"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz"
+  integrity sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==
   dependencies:
     "@types/estree" "1.0.8"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.59.0"
-    "@rollup/rollup-android-arm64" "4.59.0"
-    "@rollup/rollup-darwin-arm64" "4.59.0"
-    "@rollup/rollup-darwin-x64" "4.59.0"
-    "@rollup/rollup-freebsd-arm64" "4.59.0"
-    "@rollup/rollup-freebsd-x64" "4.59.0"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.59.0"
-    "@rollup/rollup-linux-arm-musleabihf" "4.59.0"
-    "@rollup/rollup-linux-arm64-gnu" "4.59.0"
-    "@rollup/rollup-linux-arm64-musl" "4.59.0"
-    "@rollup/rollup-linux-loong64-gnu" "4.59.0"
-    "@rollup/rollup-linux-loong64-musl" "4.59.0"
-    "@rollup/rollup-linux-ppc64-gnu" "4.59.0"
-    "@rollup/rollup-linux-ppc64-musl" "4.59.0"
-    "@rollup/rollup-linux-riscv64-gnu" "4.59.0"
-    "@rollup/rollup-linux-riscv64-musl" "4.59.0"
-    "@rollup/rollup-linux-s390x-gnu" "4.59.0"
-    "@rollup/rollup-linux-x64-gnu" "4.59.0"
-    "@rollup/rollup-linux-x64-musl" "4.59.0"
-    "@rollup/rollup-openbsd-x64" "4.59.0"
-    "@rollup/rollup-openharmony-arm64" "4.59.0"
-    "@rollup/rollup-win32-arm64-msvc" "4.59.0"
-    "@rollup/rollup-win32-ia32-msvc" "4.59.0"
-    "@rollup/rollup-win32-x64-gnu" "4.59.0"
-    "@rollup/rollup-win32-x64-msvc" "4.59.0"
+    "@rollup/rollup-android-arm-eabi" "4.57.1"
+    "@rollup/rollup-android-arm64" "4.57.1"
+    "@rollup/rollup-darwin-arm64" "4.57.1"
+    "@rollup/rollup-darwin-x64" "4.57.1"
+    "@rollup/rollup-freebsd-arm64" "4.57.1"
+    "@rollup/rollup-freebsd-x64" "4.57.1"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.57.1"
+    "@rollup/rollup-linux-arm-musleabihf" "4.57.1"
+    "@rollup/rollup-linux-arm64-gnu" "4.57.1"
+    "@rollup/rollup-linux-arm64-musl" "4.57.1"
+    "@rollup/rollup-linux-loong64-gnu" "4.57.1"
+    "@rollup/rollup-linux-loong64-musl" "4.57.1"
+    "@rollup/rollup-linux-ppc64-gnu" "4.57.1"
+    "@rollup/rollup-linux-ppc64-musl" "4.57.1"
+    "@rollup/rollup-linux-riscv64-gnu" "4.57.1"
+    "@rollup/rollup-linux-riscv64-musl" "4.57.1"
+    "@rollup/rollup-linux-s390x-gnu" "4.57.1"
+    "@rollup/rollup-linux-x64-gnu" "4.57.1"
+    "@rollup/rollup-linux-x64-musl" "4.57.1"
+    "@rollup/rollup-openbsd-x64" "4.57.1"
+    "@rollup/rollup-openharmony-arm64" "4.57.1"
+    "@rollup/rollup-win32-arm64-msvc" "4.57.1"
+    "@rollup/rollup-win32-ia32-msvc" "4.57.1"
+    "@rollup/rollup-win32-x64-gnu" "4.57.1"
+    "@rollup/rollup-win32-x64-msvc" "4.57.1"
     fsevents "~2.3.2"
 
 roughjs@^4.6.6:
   version "4.6.6"
-  resolved "https://registry.yarnpkg.com/roughjs/-/roughjs-4.6.6.tgz#1059f49a5e0c80dee541a005b20cc322b222158b"
+  resolved "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz"
   integrity sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==
   dependencies:
     hachure-fill "^0.5.2"
@@ -4160,27 +3551,27 @@ roughjs@^4.6.6:
 
 rw@1:
   version "1.3.3"
-  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  resolved "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz"
   integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sax@^1.4.1:
   version "1.4.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.4.tgz#f29c2bba80ce5b86f4343b4c2be9f2b96627cf8b"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz"
   integrity sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==
 
 semver@^7.6.3, semver@^7.7.3:
   version "7.7.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 sharp@^0.33.0:
   version "0.33.5"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.33.5.tgz#13e0e4130cc309d6a9497596715240b2ec0c594e"
+  resolved "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz"
   integrity sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==
   dependencies:
     color "^4.2.3"
@@ -4209,7 +3600,7 @@ sharp@^0.33.0:
 
 sharp@^0.34.0:
   version "0.34.5"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.34.5.tgz#b6f148e4b8c61f1797bde11a9d1cfebbae2c57b0"
+  resolved "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz"
   integrity sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==
   dependencies:
     "@img/colour" "^1.0.0"
@@ -4243,7 +3634,7 @@ sharp@^0.34.0:
 
 shiki@^1.26.1:
   version "1.29.2"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-1.29.2.tgz#5c93771f2d5305ce9c05975c33689116a27dc657"
+  resolved "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz"
   integrity sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==
   dependencies:
     "@shikijs/core" "1.29.2"
@@ -4257,7 +3648,7 @@ shiki@^1.26.1:
 
 shiki@^3.19.0, shiki@^3.21.0:
   version "3.22.0"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-3.22.0.tgz#3d590efee11feb75769354b1f64240915c3af827"
+  resolved "https://registry.npmjs.org/shiki/-/shiki-3.22.0.tgz"
   integrity sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==
   dependencies:
     "@shikijs/core" "3.22.0"
@@ -4271,19 +3662,19 @@ shiki@^3.19.0, shiki@^3.21.0:
 
 simple-swizzle@^0.2.2:
   version "0.2.4"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.4.tgz#a8d11a45a11600d6a1ecdff6363329e3648c3667"
+  resolved "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz"
   integrity sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==
   dependencies:
     is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
 sitemap@^8.0.2:
   version "8.0.2"
-  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-8.0.2.tgz#27bddb5fc2c61a1cf8f0194674cd89d762c9f5ae"
+  resolved "https://registry.npmjs.org/sitemap/-/sitemap-8.0.2.tgz"
   integrity sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ==
   dependencies:
     "@types/node" "^17.0.5"
@@ -4293,32 +3684,32 @@ sitemap@^8.0.2:
 
 smol-toml@^1.5.2, smol-toml@^1.6.0:
   version "1.6.0"
-  resolved "https://registry.yarnpkg.com/smol-toml/-/smol-toml-1.6.0.tgz#7911830b47bb3e87be536f939453e10c9e1dfd36"
+  resolved "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz"
   integrity sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==
 
 source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map@^0.7.0, source-map@^0.7.6:
   version "0.7.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz"
   integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
 
 space-separated-tokens@^2.0.0:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
+  resolved "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz"
   integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
 
 stream-replace-string@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stream-replace-string/-/stream-replace-string-2.0.0.tgz#e49fd584bd1c633613e010bc73b9db49cb5024ad"
+  resolved "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz"
   integrity sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==
 
 string-width@^4.1.0:
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
@@ -4327,7 +3718,7 @@ string-width@^4.1.0:
 
 string-width@^7.0.0, string-width@^7.2.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz"
   integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
   dependencies:
     emoji-regex "^10.3.0"
@@ -4336,7 +3727,7 @@ string-width@^7.0.0, string-width@^7.2.0:
 
 stringify-entities@^4.0.0:
   version "4.0.4"
-  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-4.0.4.tgz#b3b79ef5f277cc4ac73caeb0236c5ba939b3a4f3"
+  resolved "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz"
   integrity sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
   dependencies:
     character-entities-html4 "^2.0.0"
@@ -4344,40 +3735,40 @@ stringify-entities@^4.0.0:
 
 strip-ansi@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
 
 strip-ansi@^7.1.0:
   version "7.1.2"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.2.tgz#132875abde678c7ea8d691533f2e7e22bb744dba"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz"
   integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
   dependencies:
     ansi-regex "^6.0.1"
 
 style-to-js@^1.0.0:
   version "1.1.21"
-  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.21.tgz#2908941187f857e79e28e9cd78008b9a0b3e0e8d"
+  resolved "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz"
   integrity sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==
   dependencies:
     style-to-object "1.0.14"
 
 style-to-object@1.0.14:
   version "1.0.14"
-  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-1.0.14.tgz#1d22f0e7266bb8c6d8cae5caf4ec4f005e08f611"
+  resolved "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz"
   integrity sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==
   dependencies:
     inline-style-parser "0.2.7"
 
 stylis@^4.3.6:
   version "4.3.6"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.6.tgz#7c7b97191cb4f195f03ecab7d52f7902ed378320"
+  resolved "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz"
   integrity sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==
 
 svgo@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.0.tgz#17e0fa2eaccf429e0ec0d2179169abde9ba8ad3d"
+  resolved "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz"
   integrity sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==
   dependencies:
     commander "^11.1.0"
@@ -4390,17 +3781,17 @@ svgo@^4.0.0:
 
 tiny-inflate@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
+  resolved "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz"
   integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
 tinyexec@^1.0.1, tinyexec@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.0.2.tgz#bdd2737fe2ba40bd6f918ae26642f264b99ca251"
+  resolved "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz"
   integrity sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==
 
 tinyglobby@^0.2.13, tinyglobby@^0.2.15:
   version "0.2.15"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz"
   integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
   dependencies:
     fdir "^6.5.0"
@@ -4408,57 +3799,62 @@ tinyglobby@^0.2.13, tinyglobby@^0.2.15:
 
 trim-lines@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  resolved "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz"
   integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
 
 trough@^2.0.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
+  resolved "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz"
   integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
 
 ts-dedent@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
+  resolved "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
 tsconfck@^3.1.6:
   version "3.1.6"
-  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.1.6.tgz#da1f0b10d82237ac23422374b3fce1edb23c3ead"
+  resolved "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz"
   integrity sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==
 
 tslib@^2.4.0:
   version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-fest@^4.21.0:
   version "4.41.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz"
   integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
+"typescript@^4.9.4 || ^5.0.2", typescript@^5.0.0:
+  version "5.9.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 ufo@^1.6.1, ufo@^1.6.3:
   version "1.6.3"
-  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.3.tgz#799666e4e88c122a9659805e30b9dc071c3aed4f"
+  resolved "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz"
   integrity sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==
 
 ultrahtml@^1.6.0:
   version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ultrahtml/-/ultrahtml-1.6.0.tgz#0d1aad7bbfeae512438d30e799c11622127a1ac8"
+  resolved "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz"
   integrity sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==
 
 uncrypto@^0.1.3:
   version "0.1.3"
-  resolved "https://registry.yarnpkg.com/uncrypto/-/uncrypto-0.1.3.tgz#e1288d609226f2d02d8d69ee861fa20d8348ef2b"
+  resolved "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz"
   integrity sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==
 
-undici-types@~7.18.0:
-  version "7.18.2"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
-  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 unified@^11.0.0, unified@^11.0.4, unified@^11.0.5:
   version "11.0.5"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-11.0.5.tgz#f66677610a5c0a9ee90cab2b8d4d66037026d9e1"
+  resolved "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz"
   integrity sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==
   dependencies:
     "@types/unist" "^3.0.0"
@@ -4471,7 +3867,7 @@ unified@^11.0.0, unified@^11.0.4, unified@^11.0.5:
 
 unifont@~0.7.3:
   version "0.7.4"
-  resolved "https://registry.yarnpkg.com/unifont/-/unifont-0.7.4.tgz#62b6af68f4b602da349fc10dc92525ff93bff329"
+  resolved "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz"
   integrity sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==
   dependencies:
     css-tree "^3.1.0"
@@ -4480,7 +3876,7 @@ unifont@~0.7.3:
 
 unist-util-find-after@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz#3fccc1b086b56f34c8b798e1ff90b5c54468e896"
+  resolved "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz"
   integrity sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==
   dependencies:
     "@types/unist" "^3.0.0"
@@ -4488,14 +3884,14 @@ unist-util-find-after@^5.0.0:
 
 unist-util-is@^6.0.0:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-6.0.1.tgz#d0a3f86f2dd0db7acd7d8c2478080b5c67f9c6a9"
+  resolved "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz"
   integrity sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==
   dependencies:
     "@types/unist" "^3.0.0"
 
 unist-util-modify-children@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz#981d6308e887b005d1f491811d3cbcc254b315e9"
+  resolved "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz"
   integrity sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==
   dependencies:
     "@types/unist" "^3.0.0"
@@ -4503,21 +3899,21 @@ unist-util-modify-children@^4.0.0:
 
 unist-util-position-from-estree@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz#d94da4df596529d1faa3de506202f0c9a23f2200"
+  resolved "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz"
   integrity sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==
   dependencies:
     "@types/unist" "^3.0.0"
 
 unist-util-position@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-5.0.0.tgz#678f20ab5ca1207a97d7ea8a388373c9cf896be4"
+  resolved "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz"
   integrity sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
   dependencies:
     "@types/unist" "^3.0.0"
 
 unist-util-remove-position@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz#fea68a25658409c9460408bc6b4991b965b52163"
+  resolved "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz"
   integrity sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==
   dependencies:
     "@types/unist" "^3.0.0"
@@ -4525,21 +3921,21 @@ unist-util-remove-position@^5.0.0:
 
 unist-util-stringify-position@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  resolved "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz"
   integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
   dependencies:
     "@types/unist" "^3.0.0"
 
 unist-util-visit-children@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz#4bced199b71d7f3c397543ea6cc39e7a7f37dc7e"
+  resolved "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz"
   integrity sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==
   dependencies:
     "@types/unist" "^3.0.0"
 
 unist-util-visit-parents@^6.0.0, unist-util-visit-parents@^6.0.1, unist-util-visit-parents@^6.0.2:
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz#777df7fb98652ce16b4b7cd999d0a1a40efa3a02"
+  resolved "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz"
   integrity sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==
   dependencies:
     "@types/unist" "^3.0.0"
@@ -4547,7 +3943,7 @@ unist-util-visit-parents@^6.0.0, unist-util-visit-parents@^6.0.1, unist-util-vis
 
 unist-util-visit@^5.0.0:
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz#9a2a28b0aa76a15e0da70a08a5863a2f060e2468"
+  resolved "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz"
   integrity sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
   dependencies:
     "@types/unist" "^3.0.0"
@@ -4556,7 +3952,7 @@ unist-util-visit@^5.0.0:
 
 unstorage@^1.17.4:
   version "1.17.4"
-  resolved "https://registry.yarnpkg.com/unstorage/-/unstorage-1.17.4.tgz#92a0bca7ea3781ba80b492939c6bed17418b12f2"
+  resolved "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz"
   integrity sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==
   dependencies:
     anymatch "^3.1.3"
@@ -4570,17 +3966,17 @@ unstorage@^1.17.4:
 
 util-deprecate@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 uuid@^11.1.0:
   version "11.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 vfile-location@^5.0.0:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  resolved "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz"
   integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
   dependencies:
     "@types/unist" "^3.0.0"
@@ -4588,7 +3984,7 @@ vfile-location@^5.0.0:
 
 vfile-message@^4.0.0:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.3.tgz#87b44dddd7b70f0641c2e3ed0864ba73e2ea8df4"
+  resolved "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz"
   integrity sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==
   dependencies:
     "@types/unist" "^3.0.0"
@@ -4596,15 +3992,15 @@ vfile-message@^4.0.0:
 
 vfile@^6.0.0, vfile@^6.0.2, vfile@^6.0.3:
   version "6.0.3"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.3.tgz#3652ab1c496531852bf55a6bac57af981ebc38ab"
+  resolved "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz"
   integrity sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
-vite@^6.4.1:
+"vite@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0", vite@^6.4.1:
   version "6.4.1"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.4.1.tgz#afbe14518cdd6887e240a4b0221ab6d0ce733f96"
+  resolved "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz"
   integrity sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==
   dependencies:
     esbuild "^0.25.0"
@@ -4617,18 +4013,18 @@ vite@^6.4.1:
     fsevents "~2.3.3"
 
 vitefu@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vitefu/-/vitefu-1.1.2.tgz#b63fcf3b606170702318b8c432663a3b9030f51d"
-  integrity sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz"
+  integrity sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==
 
 vscode-jsonrpc@8.2.0:
   version "8.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz#f43dfa35fb51e763d17cd94dcca0c9458f35abf9"
+  resolved "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz"
   integrity sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==
 
 vscode-languageserver-protocol@3.17.5:
   version "3.17.5"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz#864a8b8f390835572f4e13bd9f8313d0e3ac4bea"
+  resolved "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz"
   integrity sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==
   dependencies:
     vscode-jsonrpc "8.2.0"
@@ -4636,46 +4032,46 @@ vscode-languageserver-protocol@3.17.5:
 
 vscode-languageserver-textdocument@~1.0.11:
   version "1.0.12"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz#457ee04271ab38998a093c68c2342f53f6e4a631"
+  resolved "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz"
   integrity sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==
 
 vscode-languageserver-types@3.17.5:
   version "3.17.5"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz#3273676f0cf2eab40b3f44d085acbb7f08a39d8a"
+  resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz"
   integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
 
 vscode-languageserver@~9.0.1:
   version "9.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz#500aef82097eb94df90d008678b0b6b5f474015b"
+  resolved "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz"
   integrity sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==
   dependencies:
     vscode-languageserver-protocol "3.17.5"
 
 vscode-uri@~3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.1.0.tgz#dd09ec5a66a38b5c3fffc774015713496d14e09c"
+  resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz"
   integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
 
 web-namespaces@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  resolved "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 which-pm-runs@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.1.0.tgz#35ccf7b1a0fce87bd8b92a478c9d045785d3bf35"
+  resolved "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz"
   integrity sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==
 
 widest-line@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-5.0.0.tgz#b74826a1e480783345f0cd9061b49753c9da70d0"
+  resolved "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz"
   integrity sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==
   dependencies:
     string-width "^7.0.0"
 
 wrap-ansi@^9.0.0:
   version "9.0.2"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz"
   integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
   dependencies:
     ansi-styles "^6.2.1"
@@ -4684,47 +4080,47 @@ wrap-ansi@^9.0.0:
 
 xxhash-wasm@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz#ffe7f0b98220a4afac171e3fb9b6d1f8771f015e"
+  resolved "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz"
   integrity sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==
 
 yargs-parser@^21.1.1:
   version "21.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yocto-queue@^1.1.1:
   version "1.2.2"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz"
   integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==
 
 yocto-spinner@^0.2.3:
   version "0.2.3"
-  resolved "https://registry.yarnpkg.com/yocto-spinner/-/yocto-spinner-0.2.3.tgz#e803d2f267c7f0c3188645878522066764263a13"
+  resolved "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz"
   integrity sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==
   dependencies:
     yoctocolors "^2.1.1"
 
 yoctocolors@^2.1.1:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.1.2.tgz#d795f54d173494e7d8db93150cec0ed7f678c83a"
+  resolved "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz"
   integrity sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==
 
 zod-to-json-schema@^3.25.1:
   version "3.25.1"
-  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz#7f24962101a439ddade2bf1aeab3c3bfec7d84ba"
+  resolved "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz"
   integrity sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==
 
 zod-to-ts@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/zod-to-ts/-/zod-to-ts-1.2.0.tgz#873a2fd8242d7b649237be97e0c64d7954ae0c51"
+  resolved "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz"
   integrity sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==
 
-zod@^3.25.76:
+zod@^3, "zod@^3.25 || ^4", zod@^3.25.76:
   version "3.25.76"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  resolved "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
 zwitch@^2.0.0, zwitch@^2.0.4:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  resolved "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz"
   integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
Binaries install to /usr/local/bin, which is absent from sudo's secure_path on RHEL/Oracle/Fedora, so 'sudo banyan-*' failed with command-not-found. Add a shared link_secure_path helper in install-deps.sh that symlinks each banyan binary into /usr/sbin (on secure_path everywhere), refusing to clobber a pre-existing real file. Wire it into install.sh and install-from-source.sh, and re-assert INSTALL_DIR/LINK_DIR defaults in both entry scripts.